### PR TITLE
Removed missing </p> tag

### DIFF
--- a/source/primer.md
+++ b/source/primer.md
@@ -53,7 +53,7 @@ the best overall starting point is the [Java EE Tutorial](http://docs.oracle.com
 If you've created web applications for other platforms, you
 may be able to follow along and visit the other references as needed. The core
 technologies used by Struts are also used by most other Java web development products, so
-the background information will be useful in any Java project.</p>
+the background information will be useful in any Java project.
 
 ### <a name="http"></a>HTTP, HTML and User Agents
 


### PR DESCRIPTION
In the section "General starting points", there was a missing </p> tag by the end of the last paragraph.
This tag is visible on the website (http://struts.apache.org/primer.html#general-starting-points).

This patch solves the issue.