### PR TITLE
Fixes link of "Google’s Patch Reward program"

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -27,7 +27,7 @@ title: Welcome to the Apache Struts project
         <p>During <a href="http://www.meetup.com/sfhtml5/">SFHTML5</a> Google announced that
           they extend their program to cover the Apache Struts project as well. Now you can earn
           money preparing patches for us!
-          <a href="submitting-patches.html#patch-reward">read more</a>
+          <a href="submitting-patches.html#googles-patch-reward-program">read more</a>
         </p>
       </div>
       <div class="column col-md-4">

--- a/source/submitting-patches.md
+++ b/source/submitting-patches.md
@@ -153,7 +153,7 @@ after pushing changes, `asfbot` will close the PR at GitHub.
 
  * [Git at Apache](http://wiki.apache.org/general/GitAtApache)
 
-# Google's Patch Reward program {#patch-reward}
+## Google's Patch Reward program
 
 During [SFHTML5](http://www.meetup.com/sfhtml5/) Google announced that they adding the Apache Struts project to
 [the Google's Security Patch Reward Program](https://www.google.com/about/appsecurity/patch-rewards/).


### PR DESCRIPTION
In home welcome page, when visitor clicks on "read more" of "Google's Patch Reward program" section, he/she isn't landed on beginning of section exactly. This fixes that.