### PR TITLE
Replaces all of Confluence's snippets with our own

### DIFF
--- a/source/_plugins/snippet.rb
+++ b/source/_plugins/snippet.rb
@@ -9,6 +9,12 @@ module Jekyll
     def initialize(tag_name, markup, tokens)
       parse_params(markup)
 
+      unless @url.start_with?('http')
+        @url = @url.strip.gsub!('.','/')
+        @url = 'https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/' + @url
+        @url = @url + '.java;hb=HEAD'
+      end
+
       puts 'Fetching content of url: ' + @url
 
       if @url =~ URI::regexp

--- a/source/core-developers/action-mapper.md
+++ b/source/core-developers/action-mapper.md
@@ -314,7 +314,7 @@ CompositeActionMapper
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.dispatcher.mapper.PrefixBasedActionMapper}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.dispatcher.mapper.PrefixBasedActionMapper %}
 ~~~~~~~
 
 __PrefixBasedActionProxyFactory__
@@ -322,7 +322,7 @@ __PrefixBasedActionProxyFactory__
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.factory.PrefixBasedActionProxyFactory}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.factory.PrefixBasedActionProxyFactory %}
 ~~~~~~~
 
 ####ActionMapper and ActionMapping objects####

--- a/source/core-developers/after-annotation.md
+++ b/source/core-developers/after-annotation.md
@@ -10,7 +10,7 @@ title: After Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.After}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.After %}
 ~~~~~~~
 
 #####Usage#####
@@ -18,7 +18,7 @@ title: After Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.After}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.After %}
 ~~~~~~~
 
 #####Parameters#####
@@ -26,7 +26,7 @@ title: After Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.After}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.After %}
 ~~~~~~~
 
 #####Examples#####
@@ -34,5 +34,5 @@ title: After Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.After}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.After %}
 ~~~~~~~

--- a/source/core-developers/alias-interceptor.md
+++ b/source/core-developers/alias-interceptor.md
@@ -8,7 +8,7 @@ title: Alias Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.AliasInterceptor}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.AliasInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Alias Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.AliasInterceptor}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.AliasInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -24,7 +24,7 @@ title: Alias Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.AliasInterceptor}
+{% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.AliasInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: Alias Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.AliasInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.AliasInterceptor %}
 ~~~~~~~

--- a/source/core-developers/annotation-workflow-interceptor.md
+++ b/source/core-developers/annotation-workflow-interceptor.md
@@ -6,7 +6,7 @@ title: AnnotationWorkflowInterceptor
 # AnnotationWorkflowInterceptor
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.AnnotationWorkflowInterceptor}
+{% snippet id=javadoc|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.AnnotationWorkflowInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -14,7 +14,7 @@ title: AnnotationWorkflowInterceptor
 
 
 ~~~~~~~
-{snippet:id=javacode|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.AnnotationWorkflowInterceptor}
+{% snippet id=javacode|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.AnnotationWorkflowInterceptor %}
 ~~~~~~~
 
 Configure a stack in struts\.xml that replaces the PrepareInterceptor with the AnnotationWorkflowInterceptor:
@@ -45,5 +45,5 @@ Given an Action, AnnotatedAction, add a reference to the AnnotationWorkflowInter
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.AnnotationWorkflowInterceptor}
+{% snippet id=example|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.AnnotationWorkflowInterceptor %}
 ~~~~~~~

--- a/source/core-developers/basic-validation.md
+++ b/source/core-developers/basic-validation.md
@@ -12,7 +12,7 @@ Let's configure a basic validation workflow, step by step\.
 Create the input form\.
 
 ~~~~~~~
-{snippet:id=basicValidation|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/quiz-basic.jsp}
+{% snippet id=basicValidation|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/quiz-basic.jsp %}
 ~~~~~~~
 
 #####Step 2#####
@@ -20,7 +20,7 @@ Create the input form\.
 Create the Action class\.
 
 ~~~~~~~
-{snippet:id=quizAction|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/QuizAction.java}
+{% snippet id=quizAction|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/QuizAction.java %}
 ~~~~~~~
 
 #####Step 3#####
@@ -43,7 +43,7 @@ validation.xml
 \.
 
 ~~~~~~~
-{snippet:id=quizValidators|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/QuizAction-validation.xml}
+{% snippet id=quizValidators|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/QuizAction-validation.xml %}
 ~~~~~~~
 
 #####Step 4#####

--- a/source/core-developers/before-annotation.md
+++ b/source/core-developers/before-annotation.md
@@ -10,7 +10,7 @@ title: Before Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.Before}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.Before %}
 ~~~~~~~
 
 #####Usage#####
@@ -18,7 +18,7 @@ title: Before Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.Before}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.Before %}
 ~~~~~~~
 
 #####Parameters#####
@@ -26,7 +26,7 @@ title: Before Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.Before}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.Before %}
 ~~~~~~~
 
 #####Examples#####
@@ -34,5 +34,5 @@ title: Before Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.Before}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.Before %}
 ~~~~~~~

--- a/source/core-developers/before-result-annotation.md
+++ b/source/core-developers/before-result-annotation.md
@@ -10,7 +10,7 @@ title: BeforeResult Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.BeforeResult}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.BeforeResult %}
 ~~~~~~~
 
 #####Usage#####
@@ -18,7 +18,7 @@ title: BeforeResult Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.BeforeResult}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.BeforeResult %}
 ~~~~~~~
 
 #####Parameters#####
@@ -26,7 +26,7 @@ title: BeforeResult Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.BeforeResult}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.BeforeResult %}
 ~~~~~~~
 
 #####Examples#####
@@ -34,5 +34,5 @@ title: BeforeResult Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.BeforeResult}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.BeforeResult %}
 ~~~~~~~

--- a/source/core-developers/checkbox-interceptor.md
+++ b/source/core-developers/checkbox-interceptor.md
@@ -49,7 +49,7 @@ _checkbox
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=org.apache.struts2.interceptor.CheckboxInterceptor}
+{% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.CheckboxInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -57,5 +57,5 @@ _checkbox
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=org.apache.struts2.interceptor.CheckboxInterceptor}
+{% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.CheckboxInterceptor %}
 ~~~~~~~

--- a/source/core-developers/client-validation.md
+++ b/source/core-developers/client-validation.md
@@ -26,7 +26,7 @@ true
 Create the form\.
 
 ~~~~~~~
-{snippet:id=clientValidation|lang=xml|javadoc=false|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/quiz-client.jsp}
+{% snippet id=clientValidation|lang=xml|javadoc=false|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/quiz-client.jsp %}
 ~~~~~~~
 (information) This case uses the default xhtml theme, so the 
 
@@ -40,7 +40,7 @@ Create the form\.
 Create the Action class\.
 
 ~~~~~~~
-{snippet:id=quizAction|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/QuizAction.java}
+{% snippet id=quizAction|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/QuizAction.java %}
 ~~~~~~~
 
 __Step 3__
@@ -53,7 +53,7 @@ validation.xml
  to configure the validators to be used\.
 
 ~~~~~~~
-{snippet:id=quizValidators|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/QuizAction-validation.xml}
+{% snippet id=quizValidators|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/QuizAction-validation.xml %}
 ~~~~~~~
 
 __Action and Namespace__

--- a/source/core-developers/conversion-annotation.md
+++ b/source/core-developers/conversion-annotation.md
@@ -8,7 +8,7 @@ title: Conversion Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.Conversion}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.Conversion %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: Conversion Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.Conversion}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.Conversion %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: Conversion Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.Conversion}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.Conversion %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,7 +32,7 @@ title: Conversion Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.conversion.annotations.Conversion}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.conversion.annotations.Conversion %}
 ~~~~~~~
 
 Check also [TypeConversion Annotation](type-conversion-annotation.html) for more examples!

--- a/source/core-developers/conversion-error-field-validator-annotation.md
+++ b/source/core-developers/conversion-error-field-validator-annotation.md
@@ -8,7 +8,7 @@ title: ConversionErrorFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ConversionErrorFieldValidator}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ConversionErrorFieldValidator %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: ConversionErrorFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ConversionErrorFieldValidator}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ConversionErrorFieldValidator %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: ConversionErrorFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ConversionErrorFieldValidator}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ConversionErrorFieldValidator %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: ConversionErrorFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.ConversionErrorFieldValidator}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.ConversionErrorFieldValidator %}
 ~~~~~~~

--- a/source/core-developers/conversion-error-interceptor.md
+++ b/source/core-developers/conversion-error-interceptor.md
@@ -11,14 +11,14 @@ From the Javadocs of the XWork 2 interceptor:
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.ConversionErrorInterceptor}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.ConversionErrorInterceptor %}
 ~~~~~~~
 
 From the Javadocs of the Struts 2 interceptor:
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.interceptor.StrutsConversionErrorInterceptor}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.StrutsConversionErrorInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -26,7 +26,7 @@ From the Javadocs of the Struts 2 interceptor:
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=org.apache.struts2.interceptor.StrutsConversionErrorInterceptor}
+{% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.StrutsConversionErrorInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -34,7 +34,7 @@ From the Javadocs of the Struts 2 interceptor:
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=org.apache.struts2.interceptor.StrutsConversionErrorInterceptor}
+{% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.StrutsConversionErrorInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -42,5 +42,5 @@ From the Javadocs of the Struts 2 interceptor:
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.StrutsConversionErrorInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.StrutsConversionErrorInterceptor %}
 ~~~~~~~

--- a/source/core-developers/cookie-interceptor.md
+++ b/source/core-developers/cookie-interceptor.md
@@ -8,26 +8,26 @@ title: Cookie Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.interceptor.CookieInterceptor}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.CookieInterceptor %}
 ~~~~~~~
 
 Parameters
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=org.apache.struts2.interceptor.CookieInterceptor}
+{% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.CookieInterceptor %}
 ~~~~~~~
 
 Extending the Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=org.apache.struts2.interceptor.CookieInterceptor}
+{% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.CookieInterceptor %}
 ~~~~~~~
 
 Examples
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.CookieInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.CookieInterceptor %}
 ~~~~~~~

--- a/source/core-developers/cookie-provider-interceptor.md
+++ b/source/core-developers/cookie-provider-interceptor.md
@@ -8,26 +8,26 @@ title: CookieProvider Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.interceptor.CookieProviderInterceptor}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.CookieProviderInterceptor %}
 ~~~~~~~
 
 Parameters
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=org.apache.struts2.interceptor.CookieProviderInterceptor}
+{% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.CookieProviderInterceptor %}
 ~~~~~~~
 
 Extending the Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=org.apache.struts2.interceptor.CookieProviderInterceptor}
+{% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.CookieProviderInterceptor %}
 ~~~~~~~
 
 Examples
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.CookieProviderInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.CookieProviderInterceptor %}
 ~~~~~~~

--- a/source/core-developers/create-if-null-annotation.md
+++ b/source/core-developers/create-if-null-annotation.md
@@ -8,7 +8,7 @@ title: CreateIfNull Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.util.CreateIfNull}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.util.CreateIfNull %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: CreateIfNull Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.util.CreateIfNull}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.util.CreateIfNull %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: CreateIfNull Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.util.CreateIfNull}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.util.CreateIfNull %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: CreateIfNull Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.util.CreateIfNull}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.util.CreateIfNull %}
 ~~~~~~~

--- a/source/core-developers/create-session-interceptor.md
+++ b/source/core-developers/create-session-interceptor.md
@@ -8,7 +8,7 @@ title: Create Session Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.interceptor.CreateSessionInterceptor}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.CreateSessionInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Create Session Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=org.apache.struts2.interceptor.CreateSessionInterceptor}
+{% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.CreateSessionInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -24,7 +24,7 @@ title: Create Session Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=org.apache.struts2.interceptor.CreateSessionInterceptor}
+{% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.CreateSessionInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: Create Session Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.CreateSessionInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.CreateSessionInterceptor %}
 ~~~~~~~

--- a/source/core-developers/custom-validator-annotation.md
+++ b/source/core-developers/custom-validator-annotation.md
@@ -8,7 +8,7 @@ title: CustomValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.CustomValidator}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.CustomValidator %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: CustomValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.CustomValidator}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.CustomValidator %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: CustomValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.CustomValidator}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.CustomValidator %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,7 +32,7 @@ title: CustomValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.CustomValidator}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.CustomValidator %}
 ~~~~~~~
 
 #####Adding Parameters#####

--- a/source/core-developers/date-range-field-validator-annotation.md
+++ b/source/core-developers/date-range-field-validator-annotation.md
@@ -8,7 +8,7 @@ title: DateRangeFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: DateRangeFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: DateRangeFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: DateRangeFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator %}
 ~~~~~~~

--- a/source/core-developers/debugging-interceptor.md
+++ b/source/core-developers/debugging-interceptor.md
@@ -8,12 +8,12 @@ title: DebuggingInterceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.interceptor.debugging.DebuggingInterceptor}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.debugging.DebuggingInterceptor %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=remarks|javadoc=true|url=org.apache.struts2.interceptor.debugging.DebuggingInterceptor}
+{% snippet id=remarks|javadoc=true|url=org.apache.struts2.interceptor.debugging.DebuggingInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -21,7 +21,7 @@ title: DebuggingInterceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=org.apache.struts2.interceptor.debugging.DebuggingInterceptor}
+{% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.debugging.DebuggingInterceptor %}
 ~~~~~~~
 
 #####Example#####
@@ -29,5 +29,5 @@ title: DebuggingInterceptor
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|url=org.apache.struts2.interceptor.debugging.DebuggingInterceptor}
+{% snippet id=example|javadoc=true|url=org.apache.struts2.interceptor.debugging.DebuggingInterceptor %}
 ~~~~~~~

--- a/source/core-developers/default-workflow-interceptor.md
+++ b/source/core-developers/default-workflow-interceptor.md
@@ -8,12 +8,12 @@ title: Default Workflow Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.DefaultWorkflowInterceptor}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.DefaultWorkflowInterceptor %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=javadocDefaultWorkflowInterceptor|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrefixMethodInvocationUtil}
+{% snippet id=javadocDefaultWorkflowInterceptor|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrefixMethodInvocationUtil %}
 ~~~~~~~
 
 #####Parameters#####
@@ -21,7 +21,7 @@ title: Default Workflow Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.DefaultWorkflowInterceptor}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.DefaultWorkflowInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -29,7 +29,7 @@ title: Default Workflow Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.DefaultWorkflowInterceptor}
+{% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.DefaultWorkflowInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -37,5 +37,5 @@ title: Default Workflow Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.DefaultWorkflowInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.DefaultWorkflowInterceptor %}
 ~~~~~~~

--- a/source/core-developers/double-range-field-validator-annotation.md
+++ b/source/core-developers/double-range-field-validator-annotation.md
@@ -8,7 +8,7 @@ title: DoubleRangeFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DoubleRangeFieldValidator}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DoubleRangeFieldValidator %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: DoubleRangeFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DoubleRangeFieldValidator}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DoubleRangeFieldValidator %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: DoubleRangeFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DoubleRangeFieldValidator}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DoubleRangeFieldValidator %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: DoubleRangeFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.DoubleRangeFieldValidator}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.DoubleRangeFieldValidator %}
 ~~~~~~~

--- a/source/core-developers/element-annotation.md
+++ b/source/core-developers/element-annotation.md
@@ -8,7 +8,7 @@ title: Element Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.util.Element}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.util.Element %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: Element Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.util.Element}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.util.Element %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: Element Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.util.Element}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.util.Element %}
 ~~~~~~~
 
 #####Examples#####

--- a/source/core-developers/email-validator-annotation.md
+++ b/source/core-developers/email-validator-annotation.md
@@ -8,7 +8,7 @@ title: EmailValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.EmailValidator}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.EmailValidator %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: EmailValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.EmailValidator}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.EmailValidator %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: EmailValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.EmailValidator}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.EmailValidator %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: EmailValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.EmailValidator}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.EmailValidator %}
 ~~~~~~~

--- a/source/core-developers/exception-interceptor.md
+++ b/source/core-developers/exception-interceptor.md
@@ -8,7 +8,7 @@ title: Exception Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.ExceptionMappingInterceptor}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.ExceptionMappingInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Exception Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.ExceptionMappingInterceptor}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.ExceptionMappingInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -24,7 +24,7 @@ title: Exception Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.ExceptionMappingInterceptor}
+{% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.ExceptionMappingInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: Exception Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.ExceptionMappingInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.ExceptionMappingInterceptor %}
 ~~~~~~~

--- a/source/core-developers/execute-and-wait-interceptor.md
+++ b/source/core-developers/execute-and-wait-interceptor.md
@@ -8,7 +8,7 @@ title: Execute and Wait Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.interceptor.ExecuteAndWaitInterceptor}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.ExecuteAndWaitInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Execute and Wait Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=org.apache.struts2.interceptor.ExecuteAndWaitInterceptor}
+{% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.ExecuteAndWaitInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -24,7 +24,7 @@ title: Execute and Wait Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=org.apache.struts2.interceptor.ExecuteAndWaitInterceptor}
+{% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.ExecuteAndWaitInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: Execute and Wait Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.ExecuteAndWaitInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.ExecuteAndWaitInterceptor %}
 ~~~~~~~

--- a/source/core-developers/expression-validator-annotation.md
+++ b/source/core-developers/expression-validator-annotation.md
@@ -6,7 +6,7 @@ title: ExpressionValidator Annotation
 # ExpressionValidator Annotation
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ExpressionValidator}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ExpressionValidator %}
 ~~~~~~~
 
 #####Usage#####
@@ -14,7 +14,7 @@ title: ExpressionValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ExpressionValidator}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ExpressionValidator %}
 ~~~~~~~
 
 #####Parameters#####
@@ -22,7 +22,7 @@ title: ExpressionValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ExpressionValidator}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ExpressionValidator %}
 ~~~~~~~
 
 #####Examples#####
@@ -30,5 +30,5 @@ title: ExpressionValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.ExpressionValidator}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.ExpressionValidator %}
 ~~~~~~~

--- a/source/core-developers/field-expression-validator-annotation.md
+++ b/source/core-developers/field-expression-validator-annotation.md
@@ -7,7 +7,7 @@ title: FieldExpressionValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.FieldExpressionValidator}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.FieldExpressionValidator %}
 ~~~~~~~
 
 #####Usage#####
@@ -15,7 +15,7 @@ title: FieldExpressionValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.FieldExpressionValidator}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.FieldExpressionValidator %}
 ~~~~~~~
 
 #####Parameters#####
@@ -23,7 +23,7 @@ title: FieldExpressionValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.FieldExpressionValidator}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.FieldExpressionValidator %}
 ~~~~~~~
 
 #####Examples#####
@@ -31,5 +31,5 @@ title: FieldExpressionValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.FieldExpressionValidator}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.FieldExpressionValidator %}
 ~~~~~~~

--- a/source/core-developers/file-upload-interceptor.md
+++ b/source/core-developers/file-upload-interceptor.md
@@ -13,7 +13,7 @@ title: File Upload Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -21,7 +21,7 @@ title: File Upload Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor}
+{% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -29,7 +29,7 @@ title: File Upload Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor}
+{% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -38,7 +38,7 @@ title: File Upload Interceptor
 
 
 ~~~~~~~
-{snippet:id=example-configuration|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor}
+{% snippet id=example-configuration|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
 ~~~~~~~
 
 Notice the interceptor configuration in the preceding example\. 
@@ -47,19 +47,19 @@ Notice the interceptor configuration in the preceding example\.
 
 
 ~~~~~~~
-{snippet:id=example-form|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor}
+{% snippet id=example-form|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=multipart-note|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor}
+{% snippet id=multipart-note|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
 ~~~~~~~
 
 **Example Action class:**
 
 
 ~~~~~~~
-{snippet:id=example-action|lang=java|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor}
+{% snippet id=example-action|lang=java|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
 ~~~~~~~
 
 **Setting parameters example:**

--- a/source/core-developers/file-upload.md
+++ b/source/core-developers/file-upload.md
@@ -92,7 +92,7 @@ A form must be create with a form field of type file,
 **Example JSP form tags:**
 
 ~~~~~~~
-{snippet:id=example-form|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor}
+{% snippet id=example-form|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
 ~~~~~~~
 The fileUpload interceptor will use setter injection to insert the uploaded file and related data into your Action class\. For a form field named **upload** you would provide the three setter methods shown in the following example:
 

--- a/source/core-developers/input-config-annotation.md
+++ b/source/core-developers/input-config-annotation.md
@@ -7,7 +7,7 @@ title: InputConfig Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.InputConfig}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.InputConfig %}
 ~~~~~~~
 
 #####Usage#####
@@ -15,7 +15,7 @@ title: InputConfig Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.InputConfig}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.InputConfig %}
 ~~~~~~~
 
 #####Parameters#####
@@ -23,7 +23,7 @@ title: InputConfig Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.InputConfig}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.InputConfig %}
 ~~~~~~~
 
 #####Examples#####
@@ -31,5 +31,5 @@ title: InputConfig Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.InputConfig}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.InputConfig %}
 ~~~~~~~

--- a/source/core-developers/int-range-field-validator-annotation.md
+++ b/source/core-developers/int-range-field-validator-annotation.md
@@ -7,7 +7,7 @@ title: IntRangeFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator %}
 ~~~~~~~
 
 #####Usage#####
@@ -15,7 +15,7 @@ title: IntRangeFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator %}
 ~~~~~~~
 
 #####Parameters#####
@@ -23,7 +23,7 @@ title: IntRangeFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator %}
 ~~~~~~~
 
 #####Examples#####
@@ -31,5 +31,5 @@ title: IntRangeFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator %}
 ~~~~~~~

--- a/source/core-developers/key-annotation.md
+++ b/source/core-developers/key-annotation.md
@@ -8,7 +8,7 @@ title: Key Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.util.Key}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.util.Key %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: Key Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.util.Key}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.util.Key %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: Key Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.util.Key}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.util.Key %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: Key Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.util.Key}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.util.Key %}
 ~~~~~~~

--- a/source/core-developers/key-property-annotation.md
+++ b/source/core-developers/key-property-annotation.md
@@ -8,7 +8,7 @@ title: KeyProperty Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.util.KeyProperty}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.util.KeyProperty %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: KeyProperty Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.util.KeyProperty}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.util.KeyProperty %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: KeyProperty Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.util.KeyProperty}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.util.KeyProperty %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: KeyProperty Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.util.KeyProperty}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.util.KeyProperty %}
 ~~~~~~~

--- a/source/core-developers/logger-interceptor.md
+++ b/source/core-developers/logger-interceptor.md
@@ -8,7 +8,7 @@ title: Logger Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.LoggingInterceptor}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.LoggingInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Logger Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.LoggingInterceptor}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.LoggingInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -24,7 +24,7 @@ title: Logger Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.LoggingInterceptor}
+{% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.LoggingInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: Logger Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.LoggingInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.LoggingInterceptor %}
 ~~~~~~~

--- a/source/core-developers/parameter-filter-interceptor.md
+++ b/source/core-developers/parameter-filter-interceptor.md
@@ -8,7 +8,7 @@ title: Parameter Filter Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.ParameterFilterInterceptor}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.ParameterFilterInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Parameter Filter Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.ParameterFilterInterceptor}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.ParameterFilterInterceptor %}
 ~~~~~~~
 
 #####Example#####

--- a/source/core-developers/postback-result.md
+++ b/source/core-developers/postback-result.md
@@ -10,7 +10,7 @@ title: Postback Result
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.dispatcher.PostbackResult}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.dispatcher.PostbackResult %}
 ~~~~~~~
 
 ####Parameters####
@@ -18,7 +18,7 @@ title: Postback Result
 
 
 ~~~~~~~
-{snippet:id=params|javadoc=true|url=org.apache.struts2.dispatcher.PostbackResult}
+{% snippet id=params|javadoc=true|url=org.apache.struts2.dispatcher.PostbackResult %}
 ~~~~~~~
 
 ####Examples####
@@ -26,5 +26,5 @@ title: Postback Result
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.dispatcher.PostbackResult}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.dispatcher.PostbackResult %}
 ~~~~~~~

--- a/source/core-developers/prepare-interceptor.md
+++ b/source/core-developers/prepare-interceptor.md
@@ -8,12 +8,12 @@ title: Prepare Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrepareInterceptor}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrepareInterceptor %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=javadocPrepareInterceptor|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrefixMethodInvocationUtil}
+{% snippet id=javadocPrepareInterceptor|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrefixMethodInvocationUtil %}
 ~~~~~~~
 
 #####Parameters#####
@@ -21,7 +21,7 @@ title: Prepare Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrepareInterceptor}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrepareInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -29,7 +29,7 @@ title: Prepare Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrepareInterceptor}
+{% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrepareInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -37,5 +37,5 @@ title: Prepare Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrepareInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrepareInterceptor %}
 ~~~~~~~

--- a/source/core-developers/pure-java-script-client-side-validation.md
+++ b/source/core-developers/pure-java-script-client-side-validation.md
@@ -12,7 +12,7 @@ some values will be considered acceptable by the JavaScript code but will be mar
 
 
 ~~~~~~~
-{snippet:id=supported-validators|url=struts2/core/src/main/resources/template/xhtml/form-close-validate.ftl}
+{% snippet id=supported-validators|url=struts2/core/src/main/resources/template/xhtml/form-close-validate.ftl %}
 ~~~~~~~
 
 

--- a/source/core-developers/redirect-action-result.md
+++ b/source/core-developers/redirect-action-result.md
@@ -8,7 +8,7 @@ title: Redirect Action Result
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.result.ServletActionRedirectResult}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.result.ServletActionRedirectResult %}
 ~~~~~~~
 
 
@@ -21,7 +21,7 @@ See [ActionMapper](action-mapper.html) for more details
 
 
 ~~~~~~~
-{snippet:id=params|javadoc=true|url=org.apache.struts2.result.ServletActionRedirectResult}
+{% snippet id=params|javadoc=true|url=org.apache.struts2.result.ServletActionRedirectResult %}
 ~~~~~~~
 
 ####Examples####
@@ -29,7 +29,7 @@ See [ActionMapper](action-mapper.html) for more details
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.result.ServletActionRedirectResult}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.result.ServletActionRedirectResult %}
 ~~~~~~~
 
 

--- a/source/core-developers/redirect-result.md
+++ b/source/core-developers/redirect-result.md
@@ -8,7 +8,7 @@ title: Redirect Result
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.result.ServletRedirectResult}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.result.ServletRedirectResult %}
 ~~~~~~~
 
 ####Parameters####
@@ -16,7 +16,7 @@ title: Redirect Result
 
 
 ~~~~~~~
-{snippet:id=params|javadoc=true|url=org.apache.struts2.result.ServletRedirectResult}
+{% snippet id=params|javadoc=true|url=org.apache.struts2.result.ServletRedirectResult %}
 ~~~~~~~
 
 ####Examples####
@@ -24,7 +24,7 @@ title: Redirect Result
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.result.ServletRedirectResult}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.result.ServletRedirectResult %}
 ~~~~~~~
 
 

--- a/source/core-developers/regex-field-validator-annotation.md
+++ b/source/core-developers/regex-field-validator-annotation.md
@@ -8,7 +8,7 @@ title: RegexFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RegexFieldValidator}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RegexFieldValidator %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: RegexFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RegexFieldValidator}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RegexFieldValidator %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: RegexFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RegexFieldValidator}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RegexFieldValidator %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: RegexFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.RegexFieldValidator}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.RegexFieldValidator %}
 ~~~~~~~

--- a/source/core-developers/required-field-validator-annotation.md
+++ b/source/core-developers/required-field-validator-annotation.md
@@ -7,7 +7,7 @@ title: RequiredFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator %}
 ~~~~~~~
 
 #####Usage#####
@@ -15,7 +15,7 @@ title: RequiredFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator %}
 ~~~~~~~
 
 #####Parameters#####
@@ -23,7 +23,7 @@ title: RequiredFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator %}
 ~~~~~~~
 
 #####Examples#####
@@ -31,5 +31,5 @@ title: RequiredFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator %}
 ~~~~~~~

--- a/source/core-developers/required-string-validator-annotation.md
+++ b/source/core-developers/required-string-validator-annotation.md
@@ -8,7 +8,7 @@ title: RequiredStringValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredStringValidator}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredStringValidator %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: RequiredStringValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredStringValidator}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredStringValidator %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: RequiredStringValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredStringValidator}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredStringValidator %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: RequiredStringValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.RequiredStringValidator}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.RequiredStringValidator %}
 ~~~~~~~

--- a/source/core-developers/roles-interceptor.md
+++ b/source/core-developers/roles-interceptor.md
@@ -8,7 +8,7 @@ title: Roles Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.interceptor.RolesInterceptor}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.RolesInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Roles Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=org.apache.struts2.interceptor.RolesInterceptor}
+{% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.RolesInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -24,5 +24,5 @@ title: Roles Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.RolesInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.RolesInterceptor %}
 ~~~~~~~

--- a/source/core-developers/scope-interceptor.md
+++ b/source/core-developers/scope-interceptor.md
@@ -8,7 +8,7 @@ title: Scope Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.interceptor.ScopeInterceptor}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.ScopeInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Scope Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=org.apache.struts2.interceptor.ScopeInterceptor}
+{% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.ScopeInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -24,7 +24,7 @@ title: Scope Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=org.apache.struts2.interceptor.ScopeInterceptor}
+{% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.ScopeInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,7 +32,7 @@ title: Scope Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.ScopeInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.ScopeInterceptor %}
 ~~~~~~~
 
 __Some more examples__

--- a/source/core-developers/scoped-model-driven-interceptor.md
+++ b/source/core-developers/scoped-model-driven-interceptor.md
@@ -8,7 +8,7 @@ title: Scoped Model Driven Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.ScopedModelDrivenInterceptor}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.ScopedModelDrivenInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Scoped Model Driven Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.ScopedModelDrivenInterceptor}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.ScopedModelDrivenInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -24,7 +24,7 @@ title: Scoped Model Driven Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.ScopedModelDrivenInterceptor}
+{% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.ScopedModelDrivenInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: Scoped Model Driven Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.ScopedModelDrivenInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.ScopedModelDrivenInterceptor %}
 ~~~~~~~

--- a/source/core-developers/servlet-config-interceptor.md
+++ b/source/core-developers/servlet-config-interceptor.md
@@ -8,7 +8,7 @@ title: Servlet Config Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.interceptor.ServletConfigInterceptor}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.ServletConfigInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Servlet Config Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=org.apache.struts2.interceptor.ServletConfigInterceptor}
+{% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.ServletConfigInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -24,7 +24,7 @@ title: Servlet Config Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=org.apache.struts2.interceptor.ServletConfigInterceptor}
+{% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.ServletConfigInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: Servlet Config Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.ServletConfigInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.ServletConfigInterceptor %}
 ~~~~~~~

--- a/source/core-developers/static-parameters-interceptor.md
+++ b/source/core-developers/static-parameters-interceptor.md
@@ -8,7 +8,7 @@ title: Static Parameters Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.StaticParametersInterceptor}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.StaticParametersInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Static Parameters Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.StaticParametersInterceptor}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.StaticParametersInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -24,7 +24,7 @@ title: Static Parameters Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.StaticParametersInterceptor}
+{% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.StaticParametersInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: Static Parameters Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.StaticParametersInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.StaticParametersInterceptor %}
 ~~~~~~~

--- a/source/core-developers/string-length-field-validator-annotation.md
+++ b/source/core-developers/string-length-field-validator-annotation.md
@@ -8,7 +8,7 @@ title: StringLengthFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: StringLengthFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: StringLengthFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: StringLengthFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator %}
 ~~~~~~~

--- a/source/core-developers/timer-interceptor.md
+++ b/source/core-developers/timer-interceptor.md
@@ -8,7 +8,7 @@ title: Timer Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.TimerInterceptor}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.TimerInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Timer Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.TimerInterceptor}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.TimerInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -24,7 +24,7 @@ title: Timer Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.TimerInterceptor}
+{% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.TimerInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: Timer Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.TimerInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.TimerInterceptor %}
 ~~~~~~~

--- a/source/core-developers/token-interceptor.md
+++ b/source/core-developers/token-interceptor.md
@@ -8,7 +8,7 @@ title: Token Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.interceptor.TokenInterceptor}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.TokenInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Token Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=org.apache.struts2.interceptor.TokenInterceptor}
+{% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.TokenInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -24,7 +24,7 @@ title: Token Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=org.apache.struts2.interceptor.TokenInterceptor}
+{% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.TokenInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,6 +32,6 @@ title: Token Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.TokenInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.TokenInterceptor %}
 ~~~~~~~
 

--- a/source/core-developers/token-session-interceptor.md
+++ b/source/core-developers/token-session-interceptor.md
@@ -8,7 +8,7 @@ title: Token Session Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.interceptor.TokenSessionStoreInterceptor}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.TokenSessionStoreInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Token Session Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=org.apache.struts2.interceptor.TokenSessionStoreInterceptor}
+{% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.TokenSessionStoreInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -24,7 +24,7 @@ title: Token Session Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=org.apache.struts2.interceptor.TokenSessionStoreInterceptor}
+{% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.TokenSessionStoreInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: Token Session Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.TokenSessionStoreInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.TokenSessionStoreInterceptor %}
 ~~~~~~~

--- a/source/core-developers/type-conversion-annotation.md
+++ b/source/core-developers/type-conversion-annotation.md
@@ -8,7 +8,7 @@ title: TypeConversion Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.TypeConversion}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.TypeConversion %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: TypeConversion Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.TypeConversion}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.TypeConversion %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: TypeConversion Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.TypeConversion}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.TypeConversion %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: TypeConversion Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.conversion.annotations.TypeConversion}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.conversion.annotations.TypeConversion %}
 ~~~~~~~

--- a/source/core-developers/using-field-validators.md
+++ b/source/core-developers/using-field-validators.md
@@ -14,7 +14,7 @@ __Step 1__
 Create the jsp page
 
 ~~~~~~~
-{snippet:id=fieldValidatorsExample|lang=xml|javadoc=false|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/fieldValidatorsExample.jsp}
+{% snippet id=fieldValidatorsExample|lang=xml|javadoc=false|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/fieldValidatorsExample.jsp %}
 ~~~~~~~
 
 __Step 2__
@@ -22,7 +22,7 @@ __Step 2__
 Create the action class
 
 ~~~~~~~
-{snippet:id=fieldValidatorsExample|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/FieldValidatorsExampleAction.java}
+{% snippet id=fieldValidatorsExample|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/FieldValidatorsExampleAction.java %}
 ~~~~~~~
 
 __Step 3__
@@ -30,5 +30,5 @@ __Step 3__
 Create the validator\.xml\.
 
 ~~~~~~~
-{snippet:id=fieldValidatorsExample|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/FieldValidatorsExampleAction-submitFieldValidatorsExamples-validation.xml}
+{% snippet id=fieldValidatorsExample|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/FieldValidatorsExampleAction-submitFieldValidatorsExamples-validation.xml %}
 ~~~~~~~

--- a/source/core-developers/using-non-field-validators.md
+++ b/source/core-developers/using-non-field-validators.md
@@ -14,7 +14,7 @@ __Step 1__
 Create the jsp page
 
 ~~~~~~~
-{snippet:id=nonFieldValidatorsExample|lang=xml|javadoc=false|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/nonFieldValidatorsExample.jsp}
+{% snippet id=nonFieldValidatorsExample|lang=xml|javadoc=false|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/nonFieldValidatorsExample.jsp %}
 ~~~~~~~
 
 __Step 2__
@@ -22,7 +22,7 @@ __Step 2__
 Create the action class
 
 ~~~~~~~
-{snippet:id=nonFieldValidatorsExample|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/NonFieldValidatorsExampleAction.java}
+{% snippet id=nonFieldValidatorsExample|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/NonFieldValidatorsExampleAction.java %}
 ~~~~~~~
 
 __Step 3__
@@ -30,5 +30,5 @@ __Step 3__
 Create the validator\.xml\.
 
 ~~~~~~~
-{snippet:id=nonFieldValidatorsExample|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/NonFieldValidatorsExampleAction-submitNonFieldValidatorsExamples-validation.xml}
+{% snippet id=nonFieldValidatorsExample|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/NonFieldValidatorsExampleAction-submitNonFieldValidatorsExamples-validation.xml %}
 ~~~~~~~

--- a/source/core-developers/using-visitor-field-validator.md
+++ b/source/core-developers/using-visitor-field-validator.md
@@ -14,7 +14,7 @@ __Step 1__
 Create the jsp page\.
 
 ~~~~~~~
-{snippet:id=visitorValidatorsExample|lang=xml|javadoc=false|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/visitorValidatorsExample.jsp}
+{% snippet id=visitorValidatorsExample|lang=xml|javadoc=false|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/visitorValidatorsExample.jsp %}
 ~~~~~~~
 
 __Step 2__
@@ -22,7 +22,7 @@ __Step 2__
 Create the action class\.
 
 ~~~~~~~
-{snippet:id=visitorValidatorsExample|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/VisitorValidatorsExampleAction.java}
+{% snippet id=visitorValidatorsExample|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/VisitorValidatorsExampleAction.java %}
 ~~~~~~~
 
 __Step 3__
@@ -30,5 +30,5 @@ __Step 3__
 Create the validator\.xml\.
 
 ~~~~~~~
-{snippet:id=visitorValidatorsExample|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/VisitorValidatorsExampleAction-submitVisitorValidatorsExamples-validation.xml}
+{% snippet id=visitorValidatorsExample|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/VisitorValidatorsExampleAction-submitVisitorValidatorsExamples-validation.xml %}
 ~~~~~~~

--- a/source/core-developers/validation-annotation.md
+++ b/source/core-developers/validation-annotation.md
@@ -8,7 +8,7 @@ title: Validation Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validation}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validation %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: Validation Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validation}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validation %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: Validation Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validation}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validation %}
 ~~~~~~~
 
 #####Examples#####
@@ -38,14 +38,14 @@ title: Validation Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.Validation}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.Validation %}
 ~~~~~~~
 
 **An Annotated Class**
 
 
 ~~~~~~~
-{snippet:id=example2|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.Validation}
+{% snippet id=example2|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.Validation %}
 ~~~~~~~
 
 

--- a/source/core-developers/validation-interceptor.md
+++ b/source/core-developers/validation-interceptor.md
@@ -8,7 +8,7 @@ title: Validation Interceptor
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.ValidationInterceptor}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.ValidationInterceptor %}
 ~~~~~~~
 
 #####Parameters#####
@@ -16,7 +16,7 @@ title: Validation Interceptor
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.ValidationInterceptor}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.ValidationInterceptor %}
 ~~~~~~~
 
 #####Extending the Interceptor#####
@@ -24,7 +24,7 @@ title: Validation Interceptor
 
 
 ~~~~~~~
-{snippet:id=extending|javadoc=true|url=com.opensymphony.xwork2.validator.ValidationInterceptor}
+{% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.validator.ValidationInterceptor %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: Validation Interceptor
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.validator.ValidationInterceptor}
+{% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.validator.ValidationInterceptor %}
 ~~~~~~~

--- a/source/core-developers/validation-parameter-annotation.md
+++ b/source/core-developers/validation-parameter-annotation.md
@@ -7,7 +7,7 @@ title: ValidationParameter annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ValidationParameter}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ValidationParameter %}
 ~~~~~~~
 
 __Usage__
@@ -15,7 +15,7 @@ __Usage__
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ValidationParameter}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ValidationParameter %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ValidationParameter}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ValidationParameter %}
 ~~~~~~~
 
 __Examples__
@@ -31,5 +31,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.ValidationParameter}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.ValidationParameter %}
 ~~~~~~~

--- a/source/core-developers/validations-annotation.md
+++ b/source/core-developers/validations-annotation.md
@@ -7,7 +7,7 @@ title: Validations Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validations}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validations %}
 ~~~~~~~
 
 #####Usage#####
@@ -15,7 +15,7 @@ title: Validations Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validations}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validations %}
 ~~~~~~~
 
 #####Parameters#####
@@ -23,7 +23,7 @@ title: Validations Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validations}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validations %}
 ~~~~~~~
 
 #####Examples#####
@@ -31,7 +31,7 @@ title: Validations Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.Validations}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.Validations %}
 ~~~~~~~
 
 #####Different validations per method#####

--- a/source/core-developers/velocity-result.md
+++ b/source/core-developers/velocity-result.md
@@ -8,7 +8,7 @@ title: Velocity Result
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.dispatcher.VelocityResult}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.dispatcher.VelocityResult %}
 ~~~~~~~
 
 ####Parameters####
@@ -16,7 +16,7 @@ title: Velocity Result
 
 
 ~~~~~~~
-{snippet:id=params|javadoc=true|url=org.apache.struts2.dispatcher.VelocityResult}
+{% snippet id=params|javadoc=true|url=org.apache.struts2.dispatcher.VelocityResult %}
 ~~~~~~~
 
 ####Examples####
@@ -24,5 +24,5 @@ title: Velocity Result
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.dispatcher.VelocityResult}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.dispatcher.VelocityResult %}
 ~~~~~~~

--- a/source/core-developers/visitor-field-validator-annotation.md
+++ b/source/core-developers/visitor-field-validator-annotation.md
@@ -8,7 +8,7 @@ title: VisitorFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.VisitorFieldValidator}
+{% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.VisitorFieldValidator %}
 ~~~~~~~
 
 #####Usage#####
@@ -16,7 +16,7 @@ title: VisitorFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.VisitorFieldValidator}
+{% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.VisitorFieldValidator %}
 ~~~~~~~
 
 #####Parameters#####
@@ -24,7 +24,7 @@ title: VisitorFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.VisitorFieldValidator}
+{% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.VisitorFieldValidator %}
 ~~~~~~~
 
 #####Examples#####
@@ -32,5 +32,5 @@ title: VisitorFieldValidator Annotation
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.VisitorFieldValidator}
+{% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.VisitorFieldValidator %}
 ~~~~~~~

--- a/source/plugins/plugins.md
+++ b/source/plugins/plugins.md
@@ -48,7 +48,7 @@ Extension points allow a plugin to override a key class in the Struts framework 
 
 The following extension points are available in Struts 2:
 
-{% snippet id=extensionPoints|lang=html|javadoc=true|https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/config/DefaultBeanSelectionProvider.java;hb=HEAD %}
+{% snippet id=extensionPoints|lang=html|javadoc=true|org.apache.struts2.config.DefaultBeanSelectionProvider %}
 
 ## Plugin Examples
 

--- a/source/tag-developers/action-tag.md
+++ b/source/tag-developers/action-tag.md
@@ -10,7 +10,7 @@ Please make sure you have read the [Tag Syntax](tag-syntax.html) document and un
 ## Description
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.ActionComponent}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ActionComponent %}
 ~~~~~~~
 
 Parameters can be passed to the action using nested [param](param-tag.html) tags.
@@ -40,15 +40,15 @@ Is "myAction" null outside the tag? false
 ## Examples
 
 ~~~~~~~
-{snippet:id=javacode|javadoc=true|lang=java|url=org.apache.struts2.components.ActionComponent}
+{% snippet id=javacode|javadoc=true|lang=java|url=org.apache.struts2.components.ActionComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=strutsxml|javadoc=true|lang=xml|url=org.apache.struts2.components.ActionComponent}
+{% snippet id=strutsxml|javadoc=true|lang=xml|url=org.apache.struts2.components.ActionComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.ActionComponent}
+{% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.ActionComponent %}
 ~~~~~~~

--- a/source/tag-developers/actionerror-tag.md
+++ b/source/tag-developers/actionerror-tag.md
@@ -8,17 +8,17 @@ title: Tag Developers Guide (WIP)
 ## Description
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.ActionError}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ActionError %}
 ~~~~~~~
 
 ## Parameters
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/actionerror.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/actionerror.html %}
 ~~~~~~~
 
 ## Examples
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ActionError}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ActionError %}
 ~~~~~~~

--- a/source/tag-developers/actionmessage-tag.md
+++ b/source/tag-developers/actionmessage-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.ActionMessage}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ActionMessage %}
 ~~~~~~~
 
 __Parameters__
@@ -18,7 +18,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/actionmessage.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/actionmessage.html %}
 ~~~~~~~
 
 __Examples__
@@ -26,5 +26,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ActionMessage}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ActionMessage %}
 ~~~~~~~

--- a/source/tag-developers/ajax-common-header.md
+++ b/source/tag-developers/ajax-common-header.md
@@ -21,7 +21,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 __Parameters__
@@ -29,7 +29,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/autocompleter.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/autocompleter.html %}
 ~~~~~~~
 
 __Examples__
@@ -38,63 +38,63 @@ Get list from an action:
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Uses a list:
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Autocompleter that reloads its content everytime the text changes (and the length of the text is greater than 3):
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Linking two autocompleters:
 
 
 ~~~~~~~
-{snippet:id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Set/Get selected values using JavaScript:
 
 
 ~~~~~~~
-{snippet:id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Using beforeNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Using errorNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example7|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example7|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Using errorNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example8|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example8|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Using valueNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example9|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example9|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 __Caveats__
@@ -115,7 +115,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 
 There's a bug in  IE6/IE7 which makes impossible to use the target's attribute with a parent Div, because such Div's content's are overwritten with the tag's _loadingText_ . Resulting in an "undefined" message in the content's, instead of the result of the request.
@@ -140,7 +140,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/bind.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/bind.html %}
 ~~~~~~~
 
 __Examples__
@@ -149,42 +149,42 @@ Without attaching to an event, listening to a topic (used to make an Ajax call):
 
 
 ~~~~~~~
-{snippet:id=example0|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=example0|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 
 Attached to event 'onclick' on submit button:
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 
 Submit form:
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 
 Using beforeNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 
 Using afterNotifyTopics and highlight:
 
 
 ~~~~~~~
-{snippet:id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 
 Using errorNotifyTopics and indicator:
 
 
 ~~~~~~~
-{snippet:id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 
 #####checkbox##### {#PAGE_14029}
@@ -199,7 +199,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Checkbox}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Checkbox %}
 ~~~~~~~
 
 __Parameters__
@@ -207,7 +207,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/checkbox.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/checkbox.html %}
 ~~~~~~~
 
 __Examples__
@@ -215,7 +215,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Checkbox}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Checkbox %}
 ~~~~~~~
 
 #####checkboxlist##### {#PAGE_13969}
@@ -226,14 +226,14 @@ Please make sure you have read the [Tag Syntax](#PAGE_13927) document and unders
 | 
 
 
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.ListUIBean}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ListUIBean %}
 
 __Description__
 
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.CheckboxList}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.CheckboxList %}
 ~~~~~~~
 
 __Parameters__
@@ -241,7 +241,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/checkboxlist.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/checkboxlist.html %}
 ~~~~~~~
 
 __Examples__
@@ -249,7 +249,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.CheckboxList}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.CheckboxList %}
 ~~~~~~~
 
 #####combobox##### {#PAGE_14259}
@@ -264,7 +264,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.ComboBox}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ComboBox %}
 ~~~~~~~
 
 __Parameters__
@@ -272,7 +272,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/combobox.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/combobox.html %}
 ~~~~~~~
 
 __Examples__
@@ -280,7 +280,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ComboBox}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ComboBox %}
 ~~~~~~~
 
 #####component##### {#PAGE_14033}
@@ -290,10 +290,10 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.GenericUIBean}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.GenericUIBean %}
 ~~~~~~~
 
-{snippet:id=note|javadoc=true|url=org.apache.struts2.components.GenericUIBean}
+{% snippet id=note|javadoc=true|url=org.apache.struts2.components.GenericUIBean %}
 
 **(!) templateDir and theme attribute**
 
@@ -317,7 +317,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/component.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/component.html %}
 ~~~~~~~
 
 __Examples__
@@ -325,7 +325,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.GenericUIBean}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.GenericUIBean %}
 ~~~~~~~
 
 #####datetextfield##### {#PAGE_40506485}
@@ -340,7 +340,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.DateTextField}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.DateTextField %}
 ~~~~~~~
 
 __Parameters__
@@ -348,7 +348,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/datetextfield.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/datetextfield.html %}
 ~~~~~~~
 
 __Examples__
@@ -356,7 +356,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.DateTextField}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.DateTextField %}
 ~~~~~~~
 
 #####datetimepicker##### {#PAGE_14274}
@@ -366,7 +366,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
 ~~~~~~~
 
 __Parameters__
@@ -374,7 +374,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/datetimepicker.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/datetimepicker.html %}
 ~~~~~~~
 
 __Examples__
@@ -382,21 +382,21 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
 ~~~~~~~
 
 Getting and getting the datetimepicker value, from JavaScript:
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
 ~~~~~~~
 
 Publish topic when value changes
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
 ~~~~~~~
 
 #####div##### {#PAGE_13908}
@@ -406,7 +406,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Div}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Div %}
 ~~~~~~~
 
 
@@ -420,7 +420,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/div.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/div.html %}
 ~~~~~~~
 
 #####dojo div##### {#PAGE_66929}
@@ -430,7 +430,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
 ~~~~~~~
 
 __Parameters__
@@ -438,7 +438,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/div.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/div.html %}
 ~~~~~~~
 
 __Examples__
@@ -447,21 +447,21 @@ Simple div that loads its content once:
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
 ~~~~~~~
 
 div that reloads its content every 2 seconds, and shows an indicator while reloading:
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
 ~~~~~~~
 
 div that uses topics to control the timer, highlights its content in red after reload, and submits a form:
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
 ~~~~~~~
 
 #####dojo head##### {#PAGE_66757}
@@ -469,12 +469,12 @@ div that uses topics to control the timer, highlights its content in red after r
 __Description__
 
 
-{snippet:id=notice|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java}
+{% snippet id=notice|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
 
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
 ~~~~~~~
 
 
@@ -491,7 +491,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/head.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/head.html %}
 ~~~~~~~
 
 __Examples__
@@ -499,12 +499,12 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
 ~~~~~~~
 
 #####dojo textarea##### {#PAGE_66931}
@@ -514,7 +514,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TextArea.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TextArea.java %}
 ~~~~~~~
 
 __Parameters__
@@ -522,7 +522,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/textarea.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/textarea.html %}
 ~~~~~~~
 
 #####doubleselect##### {#PAGE_14005}
@@ -533,14 +533,14 @@ Please make sure you have read the [Tag Syntax](#PAGE_13927) document and unders
 | 
 
 
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleListUIBean}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleListUIBean %}
 
 __Description__
 
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleSelect}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleSelect %}
 ~~~~~~~
 
 __Parameters__
@@ -548,7 +548,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/doubleselect.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/doubleselect.html %}
 ~~~~~~~
 
 __Examples__
@@ -556,7 +556,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.DoubleSelect}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.DoubleSelect %}
 ~~~~~~~
 
 #####fielderror##### {#PAGE_14151}
@@ -566,7 +566,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.FieldError}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.FieldError %}
 ~~~~~~~
 
 __Parameters__
@@ -574,7 +574,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/fielderror.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/fielderror.html %}
 ~~~~~~~
 
 __Examples__
@@ -582,12 +582,12 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.FieldError}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.FieldError %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.components.FieldError}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.components.FieldError %}
 ~~~~~~~
 
 #####file##### {#PAGE_14283}
@@ -602,7 +602,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.File}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.File %}
 ~~~~~~~
 
 __Parameters__
@@ -610,7 +610,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/file.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/file.html %}
 ~~~~~~~
 
 __Examples__
@@ -618,7 +618,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.File}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.File %}
 ~~~~~~~
 
 #####form##### {#PAGE_14201}
@@ -633,7 +633,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Form}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Form %}
 ~~~~~~~
 
 __Parameters__
@@ -641,7 +641,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/form.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/form.html %}
 ~~~~~~~
 
 __Examples__
@@ -649,7 +649,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Form}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Form %}
 ~~~~~~~
 
 __Validation__
@@ -668,7 +668,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Head}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Head %}
 ~~~~~~~
 
 __Parameters__
@@ -676,7 +676,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/head.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/head.html %}
 ~~~~~~~
 
 __Examples__
@@ -684,7 +684,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=org.apache.struts2.components.Head}
+{% snippet id=example1|lang=xml|javadoc=true|url=org.apache.struts2.components.Head %}
 ~~~~~~~
 
 #####hidden##### {#PAGE_14313}
@@ -699,7 +699,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Hidden}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Hidden %}
 ~~~~~~~
 
 __Parameters__
@@ -707,7 +707,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/hidden.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/hidden.html %}
 ~~~~~~~
 
 __Examples__
@@ -715,7 +715,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Hidden}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Hidden %}
 ~~~~~~~
 
 #####inputtransferselect##### {#PAGE_17268774}
@@ -725,17 +725,17 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.InputTransferSelect}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.InputTransferSelect %}
 ~~~~~~~
 
-{snippet:id=notice|javadoc=true|url=org.apache.struts2.components.InputTransferSelect}
+{% snippet id=notice|javadoc=true|url=org.apache.struts2.components.InputTransferSelect %}
 
 __Parameters__
 
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/inputtransferselect.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/inputtransferselect.html %}
 ~~~~~~~
 
 __Example__
@@ -743,7 +743,7 @@ __Example__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.InputTransferSelect}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.InputTransferSelect %}
 ~~~~~~~
 
 #####label##### {#PAGE_14167}
@@ -758,7 +758,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Label}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Label %}
 ~~~~~~~
 
 __Parameters__
@@ -766,7 +766,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/label.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/label.html %}
 ~~~~~~~
 
 __Examples__
@@ -774,12 +774,12 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Label}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Label %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.Label}
+{% snippet id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.Label %}
 ~~~~~~~
 
 #####optgroup##### {#PAGE_14170}
@@ -794,17 +794,17 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.OptGroup}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.OptGroup %}
 ~~~~~~~
 
-{snippet:id=notice|javadoc=true|url=org.apache.struts2.components.OptGroup}
+{% snippet id=notice|javadoc=true|url=org.apache.struts2.components.OptGroup %}
 
 __Parameters__
 
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/optgroup.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/optgroup.html %}
 ~~~~~~~
 
 __Examples__
@@ -812,7 +812,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.OptGroup}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.OptGroup %}
 ~~~~~~~
 
 #####optiontransferselect##### {#PAGE_13943}
@@ -823,19 +823,19 @@ Please make sure you have read the [Tag Syntax](#PAGE_13927) document and unders
 | 
 
 
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleListUIBean}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleListUIBean %}
 
 __Description__
 
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=notice|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect}
+{% snippet id=notice|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect %}
 ~~~~~~~
 
 __Parameters__
@@ -843,7 +843,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/optiontransferselect.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/optiontransferselect.html %}
 ~~~~~~~
 
 __Examples__
@@ -851,7 +851,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect %}
 ~~~~~~~
 
 #####password##### {#PAGE_13826}
@@ -866,7 +866,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Password}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Password %}
 ~~~~~~~
 
 __Parameters__
@@ -874,7 +874,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/password.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/password.html %}
 ~~~~~~~
 
 __Examples__
@@ -882,12 +882,12 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=exdescription|javadoc=true|lang=none|url=org.apache.struts2.components.Password}
+{% snippet id=exdescription|javadoc=true|lang=none|url=org.apache.struts2.components.Password %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Password}
+{% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Password %}
 ~~~~~~~
 
 #####radio##### {#PAGE_14226}
@@ -898,14 +898,14 @@ Please make sure you have read the [Tag Syntax](#PAGE_13927) document and unders
 | 
 
 
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.ListUIBean}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ListUIBean %}
 
 __Description__
 
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Radio}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Radio %}
 ~~~~~~~
 
 __Parameters__
@@ -913,7 +913,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/radio.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/radio.html %}
 ~~~~~~~
 
 __Examples__
@@ -921,17 +921,17 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=exdescription|javadoc=true|url=org.apache.struts2.components.Radio}
+{% snippet id=exdescription|javadoc=true|url=org.apache.struts2.components.Radio %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Radio}
+{% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Radio %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example_fmt|javadoc=true|lang=xml|url=org.apache.struts2.components.Radio}
+{% snippet id=example_fmt|javadoc=true|lang=xml|url=org.apache.struts2.components.Radio %}
 ~~~~~~~
 
 #####reset##### {#PAGE_13833}
@@ -946,7 +946,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Reset}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Reset %}
 ~~~~~~~
 
 __Parameters__
@@ -954,7 +954,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/reset.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/reset.html %}
 ~~~~~~~
 
 __Examples__
@@ -964,7 +964,7 @@ __Example 1__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Reset}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Reset %}
 ~~~~~~~
 
 __Example 2__
@@ -972,7 +972,7 @@ __Example 2__
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=org.apache.struts2.components.Reset}
+{% snippet id=example2|lang=xml|javadoc=true|url=org.apache.struts2.components.Reset %}
 ~~~~~~~
 
 #####select##### {#PAGE_14127}
@@ -987,7 +987,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Select}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Select %}
 ~~~~~~~
 
 __Parameters__
@@ -995,7 +995,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/select.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/select.html %}
 ~~~~~~~
 
 __Examples__
@@ -1003,12 +1003,12 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=exnote|javadoc=true|lang=none|url=org.apache.struts2.components.Select}
+{% snippet id=exnote|javadoc=true|lang=none|url=org.apache.struts2.components.Select %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Select}
+{% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Select %}
 ~~~~~~~
 
 #####submit##### {#PAGE_14054}
@@ -1023,7 +1023,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Submit}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Submit %}
 ~~~~~~~
 
 
@@ -1042,7 +1042,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/submit.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/submit.html %}
 ~~~~~~~
 
 #####tabbedPanel##### {#PAGE_14222}
@@ -1052,7 +1052,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java %}
 ~~~~~~~
 
 __Parameters__
@@ -1060,7 +1060,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/a.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/a.html %}
 ~~~~~~~
 
 __Examples__
@@ -1069,14 +1069,14 @@ The following is an example of a tabbedpanel and panel tag utilizing local and r
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java %}
 ~~~~~~~
 
 Use notify topics to prevent a tab from being selected:
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java %}
 ~~~~~~~
 
 #####textarea##### {#PAGE_13926}
@@ -1091,7 +1091,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.TextArea}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.TextArea %}
 ~~~~~~~
 
 __Parameters__
@@ -1099,7 +1099,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/textarea.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/textarea.html %}
 ~~~~~~~
 
 __Example__
@@ -1107,7 +1107,7 @@ __Example__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.TextArea}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.TextArea %}
 ~~~~~~~
 
 #####textfield##### {#PAGE_13912}
@@ -1122,7 +1122,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.TextField}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.TextField %}
 ~~~~~~~
 
 __Parameters__
@@ -1130,7 +1130,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/textfield.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/textfield.html %}
 ~~~~~~~
 
 __Examples__
@@ -1138,12 +1138,12 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.TextField}
+{% snippet id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.TextField %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.TextField}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.TextField %}
 ~~~~~~~
 
 #####token##### {#PAGE_13998}
@@ -1158,7 +1158,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Token}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Token %}
 ~~~~~~~
 
 __Parameters__
@@ -1166,7 +1166,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/token.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/token.html %}
 ~~~~~~~
 
 __Examples__
@@ -1174,7 +1174,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Token}
+{% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Token %}
 ~~~~~~~
 
 #####tree##### {#PAGE_14168}
@@ -1184,7 +1184,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
 ~~~~~~~
 
 __Parameters__
@@ -1192,7 +1192,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/tree.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/tree.html %}
 ~~~~~~~
 
 __Examples__
@@ -1201,21 +1201,21 @@ Static tree:
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
 ~~~~~~~
 
 Dynamic tree (rendered on the server):
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
 ~~~~~~~
 
 Dynamic tree loaded with AJAX (one request is made for each node):
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
 ~~~~~~~
 
 #####treenode##### {#PAGE_14288}
@@ -1225,7 +1225,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TreeNode.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TreeNode.java %}
 ~~~~~~~
 
 __Parameters__
@@ -1233,7 +1233,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/treenode.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/treenode.html %}
 ~~~~~~~
 
 __Examples__
@@ -1242,7 +1242,7 @@ Update target content with html returned from an action:
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TreeNode.java}
+{% snippet id=example|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TreeNode.java %}
 ~~~~~~~
 
 #####updownselect##### {#PAGE_13884}
@@ -1253,14 +1253,14 @@ Please make sure you have read the [Tag Syntax](#PAGE_13927) document and unders
 | 
 
 
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.ListUIBean}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ListUIBean %}
 
 __Description__
 
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.UpDownSelect}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.UpDownSelect %}
 ~~~~~~~
 
 __Parameters__
@@ -1268,7 +1268,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/updownselect.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/updownselect.html %}
 ~~~~~~~
 
 __Examples__
@@ -1276,7 +1276,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.UpDownSelect}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.UpDownSelect %}
 ~~~~~~~
 
 ####dojo anchor#### {#PAGE_66791}
@@ -1286,7 +1286,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~
 
 There's a bug in  IE6/IE7 which makes impossible to use the target's attribute with a parent Div, because such Div's content's are overwritten with the tag's _loadingText_ . Resulting in an "undefined" message in the content's, instead of the result of the request.
@@ -1310,7 +1310,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/a.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/a.html %}
 ~~~~~~~
 
 __Examples__
@@ -1319,42 +1319,42 @@ Update target content with html returned from an action:
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~
 
 Submit form(anchor inside the form):
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~
 
 Submit form(anchor outside the form):
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~
 
 Using beforeNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~
 
 Using afterNotifyTopics and highlights target:
 
 
 ~~~~~~~
-{snippet:id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~
 
 Using errorNotifyTopics and indicator:
 
 
 ~~~~~~~
-{snippet:id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~
 
 ####dojo submit#### {#PAGE_66801}
@@ -1364,7 +1364,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 There's a bug in  IE6/IE7 which makes impossible to use the target's attribute with a parent Div, because such Div's content's are overwritten with the tag's _loadingText_ . Resulting in an "undefined" message in the content's, instead of the result of the request.
@@ -1388,7 +1388,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/submit.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/submit.html %}
 ~~~~~~~
 
 __Examples__
@@ -1396,62 +1396,62 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Render an image submit:
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Render a button submit:
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Update target content with html returned from an action:
 
 
 ~~~~~~~
-{snippet:id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Submit form(inside the form):
 
 
 ~~~~~~~
-{snippet:id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Submit form(outside the form):
 
 
 ~~~~~~~
-{snippet:id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Using beforeNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example7|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example7|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Using afterNotifyTopics and highlight target:
 
 
 ~~~~~~~
-{snippet:id=example8|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example8|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Using errorNotifyTopics and indicator:
 
 
 ~~~~~~~
-{snippet:id=example9|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example9|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 

--- a/source/tag-developers/append-tag.md
+++ b/source/tag-developers/append-tag.md
@@ -10,21 +10,21 @@ Please make sure you have read the [Tag Syntax](tag-syntax.html) document and un
 ## Description
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.AppendIterator}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.AppendIterator %}
 ~~~~~~~
 
 ## Parameters
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/append.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/append.html %}
 ~~~~~~~
 
 ## Example
 
 ~~~~~~~
-{snippet:id=code|lang=java|javadoc=true|url=org.apache.struts2.components.AppendIterator}
+{% snippet id=code|lang=java|javadoc=true|url=org.apache.struts2.components.AppendIterator %}
 ~~~~~~~
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.AppendIterator}
+{% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.AppendIterator %}
 ~~~~~~~

--- a/source/tag-developers/bean-tag.md
+++ b/source/tag-developers/bean-tag.md
@@ -10,21 +10,21 @@ Please make sure you have read the [Tag Syntax](tag-syntax.html) document and un
 ## Description
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Bean}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Bean %}
 ~~~~~~~
 
 ## Parameters
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/bean.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/bean.html %}
 ~~~~~~~
 
 ## Examples
 
 ~~~~~~~
-{snippet:id=examples|javadoc=true|lang=xml|url=org.apache.struts2.components.Bean}
+{% snippet id=examples|javadoc=true|lang=xml|url=org.apache.struts2.components.Bean %}
 ~~~~~~~
 
 ~~~~~~~
-{snippet:id=examplesdescription|javadoc=true|url=org.apache.struts2.components.Bean}
+{% snippet id=examplesdescription|javadoc=true|url=org.apache.struts2.components.Bean %}
 ~~~~~~~

--- a/source/tag-developers/checkbox-tag.md
+++ b/source/tag-developers/checkbox-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Checkbox}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Checkbox %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/checkbox.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/checkbox.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,5 +31,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Checkbox}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Checkbox %}
 ~~~~~~~

--- a/source/tag-developers/checkboxlist-tag.md
+++ b/source/tag-developers/checkboxlist-tag.md
@@ -11,14 +11,14 @@ Please make sure you have read the [Tag Syntax](#PAGE_13927) document and unders
 | 
 
 
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.ListUIBean}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ListUIBean %}
 
 __Description__
 
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.CheckboxList}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.CheckboxList %}
 ~~~~~~~
 
 __Parameters__
@@ -26,7 +26,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/checkboxlist.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/checkboxlist.html %}
 ~~~~~~~
 
 __Examples__
@@ -34,5 +34,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.CheckboxList}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.CheckboxList %}
 ~~~~~~~

--- a/source/tag-developers/combobox-tag.md
+++ b/source/tag-developers/combobox-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.ComboBox}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ComboBox %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/combobox.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/combobox.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,5 +31,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ComboBox}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ComboBox %}
 ~~~~~~~

--- a/source/tag-developers/component-tag.md
+++ b/source/tag-developers/component-tag.md
@@ -9,10 +9,10 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.GenericUIBean}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.GenericUIBean %}
 ~~~~~~~
 
-{snippet:id=note|javadoc=true|url=org.apache.struts2.components.GenericUIBean}
+{% snippet id=note|javadoc=true|url=org.apache.struts2.components.GenericUIBean %}
 
 **(!) templateDir and theme attribute**
 
@@ -36,7 +36,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/component.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/component.html %}
 ~~~~~~~
 
 __Examples__
@@ -44,5 +44,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.GenericUIBean}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.GenericUIBean %}
 ~~~~~~~

--- a/source/tag-developers/date-tag.md
+++ b/source/tag-developers/date-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Date}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Date %}
 ~~~~~~~
 
 __Parameters__
@@ -18,7 +18,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/date.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/date.html %}
 ~~~~~~~
 
 __Examples__
@@ -26,5 +26,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Date}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Date %}
 ~~~~~~~

--- a/source/tag-developers/datetextfield-tag.md
+++ b/source/tag-developers/datetextfield-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.DateTextField}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.DateTextField %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/datetextfield.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/datetextfield.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,5 +31,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.DateTextField}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.DateTextField %}
 ~~~~~~~

--- a/source/tag-developers/div-tag.md
+++ b/source/tag-developers/div-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Div}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Div %}
 ~~~~~~~
 
 
@@ -24,5 +24,5 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/div.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/div.html %}
 ~~~~~~~

--- a/source/tag-developers/dojo-a-tag.md
+++ b/source/tag-developers/dojo-a-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~
 
 There's a bug in  IE6/IE7 which makes impossible to use the target's attribute with a parent Div, because such Div's content's are overwritten with the tag's _loadingText_ . Resulting in an "undefined" message in the content's, instead of the result of the request.
@@ -34,7 +34,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/a.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/a.html %}
 ~~~~~~~
 
 __Examples__
@@ -43,40 +43,40 @@ Update target content with html returned from an action:
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~
 
 Submit form(anchor inside the form):
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~
 
 Submit form(anchor outside the form):
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~
 
 Using beforeNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~
 
 Using afterNotifyTopics and highlights target:
 
 
 ~~~~~~~
-{snippet:id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~
 
 Using errorNotifyTopics and indicator:
 
 
 ~~~~~~~
-{snippet:id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java}
+{% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
 ~~~~~~~

--- a/source/tag-developers/dojo-autocompleter-tag.md
+++ b/source/tag-developers/dojo-autocompleter-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 __Parameters__
@@ -18,7 +18,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/autocompleter.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/autocompleter.html %}
 ~~~~~~~
 
 __Examples__
@@ -27,63 +27,63 @@ Get list from an action:
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Uses a list:
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Autocompleter that reloads its content everytime the text changes (and the length of the text is greater than 3):
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Linking two autocompleters:
 
 
 ~~~~~~~
-{snippet:id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Set/Get selected values using JavaScript:
 
 
 ~~~~~~~
-{snippet:id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Using beforeNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Using errorNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example7|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example7|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Using errorNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example8|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example8|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 Using valueNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example9|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java}
+{% snippet id=example9|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 ~~~~~~~
 
 __Caveats__

--- a/source/tag-developers/dojo-bind-tag.md
+++ b/source/tag-developers/dojo-bind-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 
 There's a bug in  IE6/IE7 which makes impossible to use the target's attribute with a parent Div, because such Div's content's are overwritten with the tag's _loadingText_ . Resulting in an "undefined" message in the content's, instead of the result of the request.
@@ -35,7 +35,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/bind.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/bind.html %}
 ~~~~~~~
 
 __Examples__
@@ -44,41 +44,41 @@ Without attaching to an event, listening to a topic (used to make an Ajax call):
 
 
 ~~~~~~~
-{snippet:id=example0|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=example0|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 
 Attached to event 'onclick' on submit button:
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 
 Submit form:
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 
 Using beforeNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 
 Using afterNotifyTopics and highlight:
 
 
 ~~~~~~~
-{snippet:id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 
 Using errorNotifyTopics and indicator:
 
 
 ~~~~~~~
-{snippet:id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java}
+{% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
 ~~~~~~~
 

--- a/source/tag-developers/dojo-datetimepicker-tag.md
+++ b/source/tag-developers/dojo-datetimepicker-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
 ~~~~~~~
 
 __Parameters__
@@ -18,7 +18,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/datetimepicker.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/datetimepicker.html %}
 ~~~~~~~
 
 __Examples__
@@ -26,19 +26,19 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
 ~~~~~~~
 
 Getting and getting the datetimepicker value, from JavaScript:
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
 ~~~~~~~
 
 Publish topic when value changes
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
 ~~~~~~~

--- a/source/tag-developers/dojo-div-tag.md
+++ b/source/tag-developers/dojo-div-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
 ~~~~~~~
 
 __Parameters__
@@ -18,7 +18,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/div.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/div.html %}
 ~~~~~~~
 
 __Examples__
@@ -27,19 +27,19 @@ Simple div that loads its content once:
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
 ~~~~~~~
 
 div that reloads its content every 2 seconds, and shows an indicator while reloading:
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
 ~~~~~~~
 
 div that uses topics to control the timer, highlights its content in red after reload, and submits a form:
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
 ~~~~~~~

--- a/source/tag-developers/dojo-head-tag.md
+++ b/source/tag-developers/dojo-head-tag.md
@@ -8,12 +8,12 @@ title: Tag Developers Guide (WIP)
 __Description__
 
 
-{snippet:id=notice|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java}
+{% snippet id=notice|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
 
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
 ~~~~~~~
 
 
@@ -30,7 +30,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/head.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/head.html %}
 ~~~~~~~
 
 __Examples__
@@ -38,10 +38,10 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
 ~~~~~~~

--- a/source/tag-developers/dojo-submit-tag.md
+++ b/source/tag-developers/dojo-submit-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 There's a bug in  IE6/IE7 which makes impossible to use the target's attribute with a parent Div, because such Div's content's are overwritten with the tag's _loadingText_ . Resulting in an "undefined" message in the content's, instead of the result of the request.
@@ -34,7 +34,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/submit.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/submit.html %}
 ~~~~~~~
 
 __Examples__
@@ -42,62 +42,62 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Render an image submit:
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Render a button submit:
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Update target content with html returned from an action:
 
 
 ~~~~~~~
-{snippet:id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Submit form(inside the form):
 
 
 ~~~~~~~
-{snippet:id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Submit form(outside the form):
 
 
 ~~~~~~~
-{snippet:id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Using beforeNotifyTopics:
 
 
 ~~~~~~~
-{snippet:id=example7|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example7|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Using afterNotifyTopics and highlight target:
 
 
 ~~~~~~~
-{snippet:id=example8|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example8|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 
 Using errorNotifyTopics and indicator:
 
 
 ~~~~~~~
-{snippet:id=example9|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java}
+{% snippet id=example9|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
 ~~~~~~~
 

--- a/source/tag-developers/dojo-tabbedpanel-tag.md
+++ b/source/tag-developers/dojo-tabbedpanel-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java %}
 ~~~~~~~
 
 __Parameters__
@@ -18,7 +18,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/a.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/a.html %}
 ~~~~~~~
 
 __Examples__
@@ -27,12 +27,12 @@ The following is an example of a tabbedpanel and panel tag utilizing local and r
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java %}
 ~~~~~~~
 
 Use notify topics to prevent a tab from being selected:
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java %}
 ~~~~~~~

--- a/source/tag-developers/dojo-textarea-tag.md
+++ b/source/tag-developers/dojo-textarea-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TextArea.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TextArea.java %}
 ~~~~~~~
 
 __Parameters__
@@ -18,5 +18,5 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/textarea.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/textarea.html %}
 ~~~~~~~

--- a/source/tag-developers/dojo-tree-tag.md
+++ b/source/tag-developers/dojo-tree-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
 ~~~~~~~
 
 __Parameters__
@@ -18,7 +18,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/tree.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/tree.html %}
 ~~~~~~~
 
 __Examples__
@@ -27,19 +27,19 @@ Static tree:
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java}
+{% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
 ~~~~~~~
 
 Dynamic tree (rendered on the server):
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java}
+{% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
 ~~~~~~~
 
 Dynamic tree loaded with AJAX (one request is made for each node):
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java}
+{% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
 ~~~~~~~

--- a/source/tag-developers/dojo-treenode-tag.md
+++ b/source/tag-developers/dojo-treenode-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TreeNode.java}
+{% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TreeNode.java %}
 ~~~~~~~
 
 __Parameters__
@@ -18,7 +18,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/ajax/treenode.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/treenode.html %}
 ~~~~~~~
 
 __Examples__
@@ -27,5 +27,5 @@ Update target content with html returned from an action:
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TreeNode.java}
+{% snippet id=example|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TreeNode.java %}
 ~~~~~~~

--- a/source/tag-developers/doubleselect-tag.md
+++ b/source/tag-developers/doubleselect-tag.md
@@ -11,14 +11,14 @@ Please make sure you have read the [Tag Syntax](#PAGE_13927) document and unders
 | 
 
 
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleListUIBean}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleListUIBean %}
 
 __Description__
 
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleSelect}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleSelect %}
 ~~~~~~~
 
 __Parameters__
@@ -26,7 +26,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/doubleselect.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/doubleselect.html %}
 ~~~~~~~
 
 __Examples__
@@ -34,5 +34,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.DoubleSelect}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.DoubleSelect %}
 ~~~~~~~

--- a/source/tag-developers/else-tag.md
+++ b/source/tag-developers/else-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Else}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Else %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/else.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/else.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,5 +31,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Else}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Else %}
 ~~~~~~~

--- a/source/tag-developers/elseif-tag.md
+++ b/source/tag-developers/elseif-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.ElseIf}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ElseIf %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/elseif.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/elseif.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,5 +31,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ElseIf}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ElseIf %}
 ~~~~~~~

--- a/source/tag-developers/fielderror-tag.md
+++ b/source/tag-developers/fielderror-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.FieldError}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.FieldError %}
 ~~~~~~~
 
 __Parameters__
@@ -18,7 +18,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/fielderror.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/fielderror.html %}
 ~~~~~~~
 
 __Examples__
@@ -26,10 +26,10 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.FieldError}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.FieldError %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=description|javadoc=true|url=org.apache.struts2.components.FieldError}
+{% snippet id=description|javadoc=true|url=org.apache.struts2.components.FieldError %}
 ~~~~~~~

--- a/source/tag-developers/file-tag.md
+++ b/source/tag-developers/file-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.File}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.File %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/file.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/file.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,5 +31,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.File}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.File %}
 ~~~~~~~

--- a/source/tag-developers/form-tag.md
+++ b/source/tag-developers/form-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Form}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Form %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/form.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/form.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,7 +31,7 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Form}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Form %}
 ~~~~~~~
 
 __Validation__

--- a/source/tag-developers/form-tags.md
+++ b/source/tag-developers/form-tags.md
@@ -63,7 +63,7 @@ __Template-Related Attributes__
 
 
 ~~~~~~~
-{snippet:id=templateRelatedAttributes|javadoc=true|url=org.apache.struts2.components.UIBean}
+{% snippet id=templateRelatedAttributes|javadoc=true|url=org.apache.struts2.components.UIBean %}
 ~~~~~~~
 
 __Javascript-Related Attributes__
@@ -71,7 +71,7 @@ __Javascript-Related Attributes__
 
 
 ~~~~~~~
-{snippet:id=javascriptRelatedAttributes|javadoc=true|url=org.apache.struts2.components.UIBean}
+{% snippet id=javascriptRelatedAttributes|javadoc=true|url=org.apache.struts2.components.UIBean %}
 ~~~~~~~
 
 __Tooltip Related Attributes__
@@ -79,7 +79,7 @@ __Tooltip Related Attributes__
 
 
 ~~~~~~~
-{snippet:id=tooltipattributes|javadoc=true|url=org.apache.struts2.components.UIBean}
+{% snippet id=tooltipattributes|javadoc=true|url=org.apache.struts2.components.UIBean %}
 ~~~~~~~
 
 __General Attributes__
@@ -87,7 +87,7 @@ __General Attributes__
 
 
 ~~~~~~~
-{snippet:id=generalAttributes|javadoc=true|url=org.apache.struts2.components.UIBean}
+{% snippet id=generalAttributes|javadoc=true|url=org.apache.struts2.components.UIBean %}
 ~~~~~~~
 
 
@@ -255,10 +255,10 @@ __Tooltip__
 
 
 ~~~~~~~
-{snippet:id=tooltipdescription|javadoc=true|url=org.apache.struts2.components.UIBean}
+{% snippet id=tooltipdescription|javadoc=true|url=org.apache.struts2.components.UIBean %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=tooltipexample|lang=xml|javadoc=true|url=org.apache.struts2.components.UIBean}
+{% snippet id=tooltipexample|lang=xml|javadoc=true|url=org.apache.struts2.components.UIBean %}
 ~~~~~~~

--- a/source/tag-developers/generator-tag.md
+++ b/source/tag-developers/generator-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.views.jsp.iterator.IteratorGeneratorTag}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.views.jsp.iterator.IteratorGeneratorTag %}
 ~~~~~~~
 
 __Parameters__
@@ -18,7 +18,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/generator.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/generator.html %}
 ~~~~~~~
 
 __Examples__
@@ -26,5 +26,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.IteratorGeneratorTag}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.IteratorGeneratorTag %}
 ~~~~~~~

--- a/source/tag-developers/head-tag.md
+++ b/source/tag-developers/head-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Head}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Head %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/head.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/head.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,5 +31,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=org.apache.struts2.components.Head}
+{% snippet id=example1|lang=xml|javadoc=true|url=org.apache.struts2.components.Head %}
 ~~~~~~~

--- a/source/tag-developers/hidden-tag.md
+++ b/source/tag-developers/hidden-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Hidden}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Hidden %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/hidden.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/hidden.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,5 +31,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Hidden}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Hidden %}
 ~~~~~~~

--- a/source/tag-developers/i18n-tag.md
+++ b/source/tag-developers/i18n-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.I18n}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.I18n %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/i18n.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/i18n.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,5 +31,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.I18n}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.I18n %}
 ~~~~~~~

--- a/source/tag-developers/if-tag.md
+++ b/source/tag-developers/if-tag.md
@@ -19,7 +19,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/if.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/if.html %}
 ~~~~~~~
 
 __Examples__
@@ -27,5 +27,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=struts2/core/src/main/java/org/apache/struts2/components/If.java}
+{% snippet id=example|lang=xml|javadoc=true|url=struts2/core/src/main/java/org/apache/struts2/components/If.java %}
 ~~~~~~~

--- a/source/tag-developers/include-tag.md
+++ b/source/tag-developers/include-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Include}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Include %}
 ~~~~~~~
 
 **(!) How To access parameters**
@@ -34,7 +34,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/include.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/include.html %}
 ~~~~~~~
 
 __Example__
@@ -42,10 +42,10 @@ __Example__
 
 
 ~~~~~~~
-{snippet:id=example|lang=java|javadoc=true|url=org.apache.struts2.components.Include}
+{% snippet id=example|lang=java|javadoc=true|url=org.apache.struts2.components.Include %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=exampledescription|lang=none|javadoc=true|url=org.apache.struts2.components.Include}
+{% snippet id=exampledescription|lang=none|javadoc=true|url=org.apache.struts2.components.Include %}
 ~~~~~~~

--- a/source/tag-developers/inputtransferselect-tag.md
+++ b/source/tag-developers/inputtransferselect-tag.md
@@ -10,17 +10,17 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.InputTransferSelect}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.InputTransferSelect %}
 ~~~~~~~
 
-{snippet:id=notice|javadoc=true|url=org.apache.struts2.components.InputTransferSelect}
+{% snippet id=notice|javadoc=true|url=org.apache.struts2.components.InputTransferSelect %}
 
 __Parameters__
 
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/inputtransferselect.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/inputtransferselect.html %}
 ~~~~~~~
 
 __Example__
@@ -28,5 +28,5 @@ __Example__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.InputTransferSelect}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.InputTransferSelect %}
 ~~~~~~~

--- a/source/tag-developers/iterator-tag.md
+++ b/source/tag-developers/iterator-tag.md
@@ -24,7 +24,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 __Parameters__
@@ -32,7 +32,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/iterator.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/iterator.html %}
 ~~~~~~~
 
 __Examples__
@@ -40,70 +40,70 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example1description|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example1description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example1code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example1code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example2description|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example2description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example2code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example2code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example3description|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example3description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example3code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example3code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example4description|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example4description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example4code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example4code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example5description|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example5description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example5code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example5code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example6description|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example6description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example6code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example6code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example7description|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example7description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example7code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent}
+{% snippet id=example7code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
 ~~~~~~~

--- a/source/tag-developers/label-tag.md
+++ b/source/tag-developers/label-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Label}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Label %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/label.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/label.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,10 +31,10 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Label}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Label %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.Label}
+{% snippet id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.Label %}
 ~~~~~~~

--- a/source/tag-developers/merge-tag.md
+++ b/source/tag-developers/merge-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.MergeIterator}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.MergeIterator %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/merge.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/merge.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,10 +31,10 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=javacode|lang=java|javadoc=true|url=org.apache.struts2.components.MergeIterator}
+{% snippet id=javacode|lang=java|javadoc=true|url=org.apache.struts2.components.MergeIterator %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.MergeIterator}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.MergeIterator %}
 ~~~~~~~

--- a/source/tag-developers/optgroup-tag.md
+++ b/source/tag-developers/optgroup-tag.md
@@ -15,17 +15,17 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.OptGroup}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.OptGroup %}
 ~~~~~~~
 
-{snippet:id=notice|javadoc=true|url=org.apache.struts2.components.OptGroup}
+{% snippet id=notice|javadoc=true|url=org.apache.struts2.components.OptGroup %}
 
 __Parameters__
 
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/optgroup.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/optgroup.html %}
 ~~~~~~~
 
 __Examples__
@@ -33,5 +33,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.OptGroup}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.OptGroup %}
 ~~~~~~~

--- a/source/tag-developers/optiontransferselect-tag.md
+++ b/source/tag-developers/optiontransferselect-tag.md
@@ -11,19 +11,19 @@ Please make sure you have read the [Tag Syntax](#PAGE_13927) document and unders
 | 
 
 
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleListUIBean}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleListUIBean %}
 
 __Description__
 
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=notice|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect}
+{% snippet id=notice|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect %}
 ~~~~~~~
 
 __Parameters__
@@ -31,7 +31,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/optiontransferselect.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/optiontransferselect.html %}
 ~~~~~~~
 
 __Examples__
@@ -39,5 +39,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect %}
 ~~~~~~~

--- a/source/tag-developers/param-tag.md
+++ b/source/tag-developers/param-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Param}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Param %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/param.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/param.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,10 +31,10 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Param}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Param %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=exampledescription|javadoc=true|url=org.apache.struts2.components.Param}
+{% snippet id=exampledescription|javadoc=true|url=org.apache.struts2.components.Param %}
 ~~~~~~~

--- a/source/tag-developers/password-tag.md
+++ b/source/tag-developers/password-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Password}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Password %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/password.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/password.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,10 +31,10 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=exdescription|javadoc=true|lang=none|url=org.apache.struts2.components.Password}
+{% snippet id=exdescription|javadoc=true|lang=none|url=org.apache.struts2.components.Password %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Password}
+{% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Password %}
 ~~~~~~~

--- a/source/tag-developers/property-tag.md
+++ b/source/tag-developers/property-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Property}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Property %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/property.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/property.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,10 +31,10 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Property}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Property %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=exampledescription|lang=none|javadoc=true|url=org.apache.struts2.components.Property}
+{% snippet id=exampledescription|lang=none|javadoc=true|url=org.apache.struts2.components.Property %}
 ~~~~~~~

--- a/source/tag-developers/push-tag.md
+++ b/source/tag-developers/push-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Push}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Push %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/push.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/push.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,40 +31,40 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=org.apache.struts2.components.Push}
+{% snippet id=example1|lang=xml|javadoc=true|url=org.apache.struts2.components.Push %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example1description|lang=none|javadoc=true|url=org.apache.struts2.components.Push}
+{% snippet id=example1description|lang=none|javadoc=true|url=org.apache.struts2.components.Push %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=org.apache.struts2.components.Push}
+{% snippet id=example2|lang=xml|javadoc=true|url=org.apache.struts2.components.Push %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example2description|lang=none|javadoc=true|url=org.apache.struts2.components.Push}
+{% snippet id=example2description|lang=none|javadoc=true|url=org.apache.struts2.components.Push %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=org.apache.struts2.components.Push}
+{% snippet id=example3|lang=xml|javadoc=true|url=org.apache.struts2.components.Push %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example3description|lang=none|javadoc=true|url=org.apache.struts2.components.Push}
+{% snippet id=example3description|lang=none|javadoc=true|url=org.apache.struts2.components.Push %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example4|lang=xml|javadoc=true|url=org.apache.struts2.components.Push}
+{% snippet id=example4|lang=xml|javadoc=true|url=org.apache.struts2.components.Push %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example4description|lang=none|javadoc=true|url=org.apache.struts2.components.Push}
+{% snippet id=example4description|lang=none|javadoc=true|url=org.apache.struts2.components.Push %}
 ~~~~~~~

--- a/source/tag-developers/radio-tag.md
+++ b/source/tag-developers/radio-tag.md
@@ -11,14 +11,14 @@ Please make sure you have read the [Tag Syntax](#PAGE_13927) document and unders
 | 
 
 
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.ListUIBean}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ListUIBean %}
 
 __Description__
 
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Radio}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Radio %}
 ~~~~~~~
 
 __Parameters__
@@ -26,7 +26,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/radio.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/radio.html %}
 ~~~~~~~
 
 __Examples__
@@ -34,15 +34,15 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=exdescription|javadoc=true|url=org.apache.struts2.components.Radio}
+{% snippet id=exdescription|javadoc=true|url=org.apache.struts2.components.Radio %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Radio}
+{% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Radio %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example_fmt|javadoc=true|lang=xml|url=org.apache.struts2.components.Radio}
+{% snippet id=example_fmt|javadoc=true|lang=xml|url=org.apache.struts2.components.Radio %}
 ~~~~~~~

--- a/source/tag-developers/reset-tag.md
+++ b/source/tag-developers/reset-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Reset}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Reset %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/reset.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/reset.html %}
 ~~~~~~~
 
 __Examples__
@@ -33,7 +33,7 @@ __Example 1__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Reset}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Reset %}
 ~~~~~~~
 
 __Example 2__
@@ -41,5 +41,5 @@ __Example 2__
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=org.apache.struts2.components.Reset}
+{% snippet id=example2|lang=xml|javadoc=true|url=org.apache.struts2.components.Reset %}
 ~~~~~~~

--- a/source/tag-developers/select-tag.md
+++ b/source/tag-developers/select-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Select}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Select %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/select.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/select.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,10 +31,10 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=exnote|javadoc=true|lang=none|url=org.apache.struts2.components.Select}
+{% snippet id=exnote|javadoc=true|lang=none|url=org.apache.struts2.components.Select %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Select}
+{% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Select %}
 ~~~~~~~

--- a/source/tag-developers/set-tag.md
+++ b/source/tag-developers/set-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Set}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Set %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/set.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/set.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,5 +31,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Set}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Set %}
 ~~~~~~~

--- a/source/tag-developers/sort-tag.md
+++ b/source/tag-developers/sort-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SortIteratorTag}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SortIteratorTag %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|url=struts2-tags/sort.html}
+{% snippet id=tagattributes|url=struts2-tags/sort.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,5 +31,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SortIteratorTag}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SortIteratorTag %}
 ~~~~~~~

--- a/source/tag-developers/submit-tag.md
+++ b/source/tag-developers/submit-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Submit}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Submit %}
 ~~~~~~~
 
 
@@ -34,5 +34,5 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/submit.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/submit.html %}
 ~~~~~~~

--- a/source/tag-developers/subset-tag.md
+++ b/source/tag-developers/subset-tag.md
@@ -10,7 +10,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
 ~~~~~~~
 
 __Parameters__
@@ -18,7 +18,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/subset.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/subset.html %}
 ~~~~~~~
 
 __Examples__
@@ -26,30 +26,30 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=action|lang=java|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag}
+{% snippet id=action|lang=java|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example1|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag}
+{% snippet id=example1|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example2|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag}
+{% snippet id=example2|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example3|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag}
+{% snippet id=example3|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example4|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag}
+{% snippet id=example4|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example5|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag}
+{% snippet id=example5|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
 ~~~~~~~

--- a/source/tag-developers/text-tag.md
+++ b/source/tag-developers/text-tag.md
@@ -14,7 +14,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Text}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Text %}
 ~~~~~~~
 
 For more details on using resource bundles with Struts 2 read the _localization guide_ .
@@ -24,7 +24,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/text.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/text.html %}
 ~~~~~~~
 
 __Examples__
@@ -32,12 +32,12 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.Text}
+{% snippet id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.Text %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Text}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Text %}
 ~~~~~~~
 
 Other example

--- a/source/tag-developers/textarea-tag.md
+++ b/source/tag-developers/textarea-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.TextArea}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.TextArea %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/textarea.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/textarea.html %}
 ~~~~~~~
 
 __Example__
@@ -31,5 +31,5 @@ __Example__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.TextArea}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.TextArea %}
 ~~~~~~~

--- a/source/tag-developers/textfield-tag.md
+++ b/source/tag-developers/textfield-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.TextField}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.TextField %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/textfield.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/textfield.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,10 +31,10 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.TextField}
+{% snippet id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.TextField %}
 ~~~~~~~
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.TextField}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.TextField %}
 ~~~~~~~

--- a/source/tag-developers/token-tag.md
+++ b/source/tag-developers/token-tag.md
@@ -15,7 +15,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.Token}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Token %}
 ~~~~~~~
 
 __Parameters__
@@ -23,7 +23,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/token.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/token.html %}
 ~~~~~~~
 
 __Examples__
@@ -31,5 +31,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Token}
+{% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Token %}
 ~~~~~~~

--- a/source/tag-developers/updownselect-tag.md
+++ b/source/tag-developers/updownselect-tag.md
@@ -11,14 +11,14 @@ Please make sure you have read the [Tag Syntax](#PAGE_13927) document and unders
 | 
 
 
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.ListUIBean}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ListUIBean %}
 
 __Description__
 
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.UpDownSelect}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.UpDownSelect %}
 ~~~~~~~
 
 __Parameters__
@@ -26,7 +26,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/updownselect.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/updownselect.html %}
 ~~~~~~~
 
 __Examples__
@@ -34,5 +34,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.UpDownSelect}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.UpDownSelect %}
 ~~~~~~~

--- a/source/tag-developers/url-tag.md
+++ b/source/tag-developers/url-tag.md
@@ -20,7 +20,7 @@ __Description__
 
 
 ~~~~~~~
-{snippet:id=javadoc|javadoc=true|url=org.apache.struts2.components.URL}
+{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.URL %}
 ~~~~~~~
 
 __Setting a default value for includeParams__
@@ -56,7 +56,7 @@ __Parameters__
 
 
 ~~~~~~~
-{snippet:id=tagattributes|javadoc=false|url=struts2-tags/url.html}
+{% snippet id=tagattributes|javadoc=false|url=struts2-tags/url.html %}
 ~~~~~~~
 
 __Examples__
@@ -64,5 +64,5 @@ __Examples__
 
 
 ~~~~~~~
-{snippet:id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.URL}
+{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.URL %}
 ~~~~~~~


### PR DESCRIPTION
Also add support loading by `Fully Qualified Class Name` to `snippet.rb` 👍 

I kept `~~~~~~~`s unchanged because I tested with \`\`\` and over 600 http requests and snippet render took a lot of time :S