### PR TITLE
Un-comment and fixes all snippets

### DIFF
--- a/source/core-developers/action-mapper.md
+++ b/source/core-developers/action-mapper.md
@@ -313,17 +313,13 @@ CompositeActionMapper
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.dispatcher.mapper.PrefixBasedActionMapper %}
-~~~~~~~
 
 __PrefixBasedActionProxyFactory__
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.factory.PrefixBasedActionProxyFactory %}
-~~~~~~~
 
 ####ActionMapper and ActionMapping objects####
 

--- a/source/core-developers/after-annotation.md
+++ b/source/core-developers/after-annotation.md
@@ -9,30 +9,22 @@ title: After Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.After %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.After %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.After %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.After %}
-~~~~~~~

--- a/source/core-developers/alias-interceptor.md
+++ b/source/core-developers/alias-interceptor.md
@@ -7,30 +7,22 @@ title: Alias Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.AliasInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.AliasInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.AliasInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.AliasInterceptor %}
-~~~~~~~

--- a/source/core-developers/annotation-workflow-interceptor.md
+++ b/source/core-developers/annotation-workflow-interceptor.md
@@ -5,17 +5,13 @@ title: AnnotationWorkflowInterceptor
 
 # AnnotationWorkflowInterceptor
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.AnnotationWorkflowInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=javacode|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.AnnotationWorkflowInterceptor %}
-~~~~~~~
 
 Configure a stack in struts\.xml that replaces the PrepareInterceptor with the AnnotationWorkflowInterceptor:
 
@@ -44,6 +40,4 @@ Given an Action, AnnotatedAction, add a reference to the AnnotationWorkflowInter
 ~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.AnnotationWorkflowInterceptor %}
-~~~~~~~

--- a/source/core-developers/basic-validation.md
+++ b/source/core-developers/basic-validation.md
@@ -11,17 +11,13 @@ Let's configure a basic validation workflow, step by step\.
 
 Create the input form\.
 
-~~~~~~~
 {% snippet id=basicValidation|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/quiz-basic.jsp %}
-~~~~~~~
 
 #####Step 2#####
 
 Create the Action class\.
 
-~~~~~~~
 {% snippet id=quizAction|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/QuizAction.java %}
-~~~~~~~
 
 #####Step 3#####
 
@@ -42,9 +38,7 @@ validation.xml
 ~~~~~~~
 \.
 
-~~~~~~~
 {% snippet id=quizValidators|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/QuizAction-validation.xml %}
-~~~~~~~
 
 #####Step 4#####
 

--- a/source/core-developers/before-annotation.md
+++ b/source/core-developers/before-annotation.md
@@ -9,30 +9,22 @@ title: Before Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.Before %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.Before %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.Before %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.Before %}
-~~~~~~~

--- a/source/core-developers/before-result-annotation.md
+++ b/source/core-developers/before-result-annotation.md
@@ -9,30 +9,22 @@ title: BeforeResult Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.BeforeResult %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.BeforeResult %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.BeforeResult %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.BeforeResult %}
-~~~~~~~

--- a/source/core-developers/checkbox-interceptor.md
+++ b/source/core-developers/checkbox-interceptor.md
@@ -48,14 +48,10 @@ _checkbox
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.CheckboxInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.CheckboxInterceptor %}
-~~~~~~~

--- a/source/core-developers/client-validation.md
+++ b/source/core-developers/client-validation.md
@@ -25,9 +25,7 @@ true
 
 Create the form\.
 
-~~~~~~~
 {% snippet id=clientValidation|lang=xml|javadoc=false|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/quiz-client.jsp %}
-~~~~~~~
 (information) This case uses the default xhtml theme, so the 
 
 ~~~~~~~
@@ -39,9 +37,7 @@ Create the form\.
 
 Create the Action class\.
 
-~~~~~~~
 {% snippet id=quizAction|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/QuizAction.java %}
-~~~~~~~
 
 __Step 3__
 
@@ -52,9 +48,7 @@ validation.xml
 ~~~~~~~
  to configure the validators to be used\.
 
-~~~~~~~
 {% snippet id=quizValidators|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/QuizAction-validation.xml %}
-~~~~~~~
 
 __Action and Namespace__
 

--- a/source/core-developers/conversion-annotation.md
+++ b/source/core-developers/conversion-annotation.md
@@ -7,32 +7,24 @@ title: Conversion Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.Conversion %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.Conversion %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.Conversion %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.conversion.annotations.Conversion %}
-~~~~~~~
 
 Check also [TypeConversion Annotation](type-conversion-annotation.html) for more examples!

--- a/source/core-developers/conversion-error-field-validator-annotation.md
+++ b/source/core-developers/conversion-error-field-validator-annotation.md
@@ -7,30 +7,22 @@ title: ConversionErrorFieldValidator Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ConversionErrorFieldValidator %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ConversionErrorFieldValidator %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ConversionErrorFieldValidator %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.ConversionErrorFieldValidator %}
-~~~~~~~

--- a/source/core-developers/conversion-error-interceptor.md
+++ b/source/core-developers/conversion-error-interceptor.md
@@ -10,37 +10,27 @@ The Struts 2 conversion error interceptor is a subclass of the XWork 2 conversio
 From the Javadocs of the XWork 2 interceptor:
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.ConversionErrorInterceptor %}
-~~~~~~~
 
 From the Javadocs of the Struts 2 interceptor:
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.StrutsConversionErrorInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.StrutsConversionErrorInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.StrutsConversionErrorInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.StrutsConversionErrorInterceptor %}
-~~~~~~~

--- a/source/core-developers/cookie-interceptor.md
+++ b/source/core-developers/cookie-interceptor.md
@@ -7,27 +7,19 @@ title: Cookie Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.CookieInterceptor %}
-~~~~~~~
 
 Parameters
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.CookieInterceptor %}
-~~~~~~~
 
 Extending the Interceptor
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.CookieInterceptor %}
-~~~~~~~
 
 Examples
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.CookieInterceptor %}
-~~~~~~~

--- a/source/core-developers/cookie-provider-interceptor.md
+++ b/source/core-developers/cookie-provider-interceptor.md
@@ -7,27 +7,19 @@ title: CookieProvider Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.CookieProviderInterceptor %}
-~~~~~~~
 
 Parameters
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.CookieProviderInterceptor %}
-~~~~~~~
 
 Extending the Interceptor
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.CookieProviderInterceptor %}
-~~~~~~~
 
 Examples
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.CookieProviderInterceptor %}
-~~~~~~~

--- a/source/core-developers/create-if-null-annotation.md
+++ b/source/core-developers/create-if-null-annotation.md
@@ -7,30 +7,22 @@ title: CreateIfNull Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.util.CreateIfNull %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.util.CreateIfNull %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.util.CreateIfNull %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.util.CreateIfNull %}
-~~~~~~~

--- a/source/core-developers/create-session-interceptor.md
+++ b/source/core-developers/create-session-interceptor.md
@@ -7,30 +7,22 @@ title: Create Session Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.CreateSessionInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.CreateSessionInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.CreateSessionInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.CreateSessionInterceptor %}
-~~~~~~~

--- a/source/core-developers/custom-validator-annotation.md
+++ b/source/core-developers/custom-validator-annotation.md
@@ -7,33 +7,25 @@ title: CustomValidator Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.CustomValidator %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.CustomValidator %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.CustomValidator %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.CustomValidator %}
-~~~~~~~
 
 #####Adding Parameters#####
 

--- a/source/core-developers/date-range-field-validator-annotation.md
+++ b/source/core-developers/date-range-field-validator-annotation.md
@@ -7,30 +7,22 @@ title: DateRangeFieldValidator Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator %}
-~~~~~~~

--- a/source/core-developers/debugging-interceptor.md
+++ b/source/core-developers/debugging-interceptor.md
@@ -7,27 +7,19 @@ title: DebuggingInterceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.debugging.DebuggingInterceptor %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=remarks|javadoc=true|url=org.apache.struts2.interceptor.debugging.DebuggingInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.debugging.DebuggingInterceptor %}
-~~~~~~~
 
 #####Example#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|url=org.apache.struts2.interceptor.debugging.DebuggingInterceptor %}
-~~~~~~~

--- a/source/core-developers/default-workflow-interceptor.md
+++ b/source/core-developers/default-workflow-interceptor.md
@@ -7,35 +7,25 @@ title: Default Workflow Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.DefaultWorkflowInterceptor %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=javadocDefaultWorkflowInterceptor|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrefixMethodInvocationUtil %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.DefaultWorkflowInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.DefaultWorkflowInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.DefaultWorkflowInterceptor %}
-~~~~~~~

--- a/source/core-developers/double-range-field-validator-annotation.md
+++ b/source/core-developers/double-range-field-validator-annotation.md
@@ -7,30 +7,22 @@ title: DoubleRangeFieldValidator Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DoubleRangeFieldValidator %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DoubleRangeFieldValidator %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.DoubleRangeFieldValidator %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.DoubleRangeFieldValidator %}
-~~~~~~~

--- a/source/core-developers/element-annotation.md
+++ b/source/core-developers/element-annotation.md
@@ -7,25 +7,19 @@ title: Element Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.util.Element %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.util.Element %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.util.Element %}
-~~~~~~~
 
 #####Examples#####
 

--- a/source/core-developers/email-validator-annotation.md
+++ b/source/core-developers/email-validator-annotation.md
@@ -7,30 +7,22 @@ title: EmailValidator Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.EmailValidator %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.EmailValidator %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.EmailValidator %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.EmailValidator %}
-~~~~~~~

--- a/source/core-developers/exception-interceptor.md
+++ b/source/core-developers/exception-interceptor.md
@@ -7,30 +7,22 @@ title: Exception Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.ExceptionMappingInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.ExceptionMappingInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.ExceptionMappingInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.ExceptionMappingInterceptor %}
-~~~~~~~

--- a/source/core-developers/execute-and-wait-interceptor.md
+++ b/source/core-developers/execute-and-wait-interceptor.md
@@ -7,30 +7,22 @@ title: Execute and Wait Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.ExecuteAndWaitInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.ExecuteAndWaitInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.ExecuteAndWaitInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.ExecuteAndWaitInterceptor %}
-~~~~~~~

--- a/source/core-developers/expression-validator-annotation.md
+++ b/source/core-developers/expression-validator-annotation.md
@@ -5,30 +5,22 @@ title: ExpressionValidator Annotation
 
 # ExpressionValidator Annotation
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ExpressionValidator %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ExpressionValidator %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ExpressionValidator %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.ExpressionValidator %}
-~~~~~~~

--- a/source/core-developers/field-expression-validator-annotation.md
+++ b/source/core-developers/field-expression-validator-annotation.md
@@ -6,30 +6,22 @@ title: FieldExpressionValidator Annotation
 # FieldExpressionValidator Annotation
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.FieldExpressionValidator %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.FieldExpressionValidator %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.FieldExpressionValidator %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.FieldExpressionValidator %}
-~~~~~~~

--- a/source/core-developers/file-upload-interceptor.md
+++ b/source/core-developers/file-upload-interceptor.md
@@ -12,55 +12,41 @@ title: File Upload Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 **Example action mapping:**
 
 
-~~~~~~~
 {% snippet id=example-configuration|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
-~~~~~~~
 
 Notice the interceptor configuration in the preceding example\. 
 
 **Example JSP form tags:**
 
 
-~~~~~~~
 {% snippet id=example-form|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=multipart-note|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
-~~~~~~~
 
 **Example Action class:**
 
 
-~~~~~~~
 {% snippet id=example-action|lang=java|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
-~~~~~~~
 
 **Setting parameters example:**
 

--- a/source/core-developers/file-upload.md
+++ b/source/core-developers/file-upload.md
@@ -91,9 +91,7 @@ A form must be create with a form field of type file,
 
 **Example JSP form tags:**
 
-~~~~~~~
 {% snippet id=example-form|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.FileUploadInterceptor %}
-~~~~~~~
 The fileUpload interceptor will use setter injection to insert the uploaded file and related data into your Action class\. For a form field named **upload** you would provide the three setter methods shown in the following example:
 
 **Example Action class:**

--- a/source/core-developers/input-config-annotation.md
+++ b/source/core-developers/input-config-annotation.md
@@ -6,30 +6,22 @@ title: InputConfig Annotation
 # InputConfig Annotation
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.InputConfig %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.InputConfig %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.annotations.InputConfig %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.interceptor.annotations.InputConfig %}
-~~~~~~~

--- a/source/core-developers/int-range-field-validator-annotation.md
+++ b/source/core-developers/int-range-field-validator-annotation.md
@@ -6,30 +6,22 @@ title: IntRangeFieldValidator Annotation
 # IntRangeFieldValidator Annotation
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator %}
-~~~~~~~

--- a/source/core-developers/key-annotation.md
+++ b/source/core-developers/key-annotation.md
@@ -7,30 +7,22 @@ title: Key Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.util.Key %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.util.Key %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.util.Key %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.util.Key %}
-~~~~~~~

--- a/source/core-developers/key-property-annotation.md
+++ b/source/core-developers/key-property-annotation.md
@@ -7,30 +7,22 @@ title: KeyProperty Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.util.KeyProperty %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.util.KeyProperty %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.util.KeyProperty %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.util.KeyProperty %}
-~~~~~~~

--- a/source/core-developers/logger-interceptor.md
+++ b/source/core-developers/logger-interceptor.md
@@ -7,30 +7,22 @@ title: Logger Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.LoggingInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.LoggingInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.LoggingInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.LoggingInterceptor %}
-~~~~~~~

--- a/source/core-developers/parameter-filter-interceptor.md
+++ b/source/core-developers/parameter-filter-interceptor.md
@@ -7,17 +7,13 @@ title: Parameter Filter Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.ParameterFilterInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.ParameterFilterInterceptor %}
-~~~~~~~
 
 #####Example#####
 

--- a/source/core-developers/postback-result.md
+++ b/source/core-developers/postback-result.md
@@ -9,22 +9,16 @@ title: Postback Result
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.dispatcher.PostbackResult %}
-~~~~~~~
 
 ####Parameters####
 
 
 
-~~~~~~~
 {% snippet id=params|javadoc=true|url=org.apache.struts2.dispatcher.PostbackResult %}
-~~~~~~~
 
 ####Examples####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.dispatcher.PostbackResult %}
-~~~~~~~

--- a/source/core-developers/prepare-interceptor.md
+++ b/source/core-developers/prepare-interceptor.md
@@ -7,35 +7,25 @@ title: Prepare Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrepareInterceptor %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=javadocPrepareInterceptor|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrefixMethodInvocationUtil %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrepareInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrepareInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.PrepareInterceptor %}
-~~~~~~~

--- a/source/core-developers/pure-java-script-client-side-validation.md
+++ b/source/core-developers/pure-java-script-client-side-validation.md
@@ -11,9 +11,7 @@ Because the validation logic is actually repeated in the JavaScript code, it is 
 some values will be considered acceptable by the JavaScript code but will be marked as unacceptable by the server\-side [Validation](validation.html).
 
 
-~~~~~~~
 {% snippet id=supported-validators|url=struts2/core/src/main/resources/template/xhtml/form-close-validate.ftl %}
-~~~~~~~
 
 
 > 

--- a/source/core-developers/redirect-action-result.md
+++ b/source/core-developers/redirect-action-result.md
@@ -7,9 +7,7 @@ title: Redirect Action Result
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.result.ServletActionRedirectResult %}
-~~~~~~~
 
 
 See [ActionMapper](action-mapper.html) for more details
@@ -20,17 +18,13 @@ See [ActionMapper](action-mapper.html) for more details
 
 
 
-~~~~~~~
 {% snippet id=params|javadoc=true|url=org.apache.struts2.result.ServletActionRedirectResult %}
-~~~~~~~
 
 ####Examples####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.result.ServletActionRedirectResult %}
-~~~~~~~
 
 
 

--- a/source/core-developers/redirect-result.md
+++ b/source/core-developers/redirect-result.md
@@ -7,25 +7,19 @@ title: Redirect Result
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.result.ServletRedirectResult %}
-~~~~~~~
 
 ####Parameters####
 
 
 
-~~~~~~~
 {% snippet id=params|javadoc=true|url=org.apache.struts2.result.ServletRedirectResult %}
-~~~~~~~
 
 ####Examples####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.result.ServletRedirectResult %}
-~~~~~~~
 
 
 

--- a/source/core-developers/regex-field-validator-annotation.md
+++ b/source/core-developers/regex-field-validator-annotation.md
@@ -7,30 +7,22 @@ title: RegexFieldValidator Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RegexFieldValidator %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RegexFieldValidator %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RegexFieldValidator %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.RegexFieldValidator %}
-~~~~~~~

--- a/source/core-developers/required-field-validator-annotation.md
+++ b/source/core-developers/required-field-validator-annotation.md
@@ -6,30 +6,22 @@ title: RequiredFieldValidator Annotation
 # RequiredFieldValidator Annotation
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator %}
-~~~~~~~

--- a/source/core-developers/required-string-validator-annotation.md
+++ b/source/core-developers/required-string-validator-annotation.md
@@ -7,30 +7,22 @@ title: RequiredStringValidator Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredStringValidator %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredStringValidator %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.RequiredStringValidator %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.RequiredStringValidator %}
-~~~~~~~

--- a/source/core-developers/roles-interceptor.md
+++ b/source/core-developers/roles-interceptor.md
@@ -7,22 +7,16 @@ title: Roles Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.RolesInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.RolesInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.RolesInterceptor %}
-~~~~~~~

--- a/source/core-developers/scope-interceptor.md
+++ b/source/core-developers/scope-interceptor.md
@@ -7,33 +7,25 @@ title: Scope Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.ScopeInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.ScopeInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.ScopeInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.ScopeInterceptor %}
-~~~~~~~
 
 __Some more examples__
 

--- a/source/core-developers/scoped-model-driven-interceptor.md
+++ b/source/core-developers/scoped-model-driven-interceptor.md
@@ -7,30 +7,22 @@ title: Scoped Model Driven Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.ScopedModelDrivenInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.ScopedModelDrivenInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.ScopedModelDrivenInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.ScopedModelDrivenInterceptor %}
-~~~~~~~

--- a/source/core-developers/servlet-config-interceptor.md
+++ b/source/core-developers/servlet-config-interceptor.md
@@ -7,30 +7,22 @@ title: Servlet Config Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.ServletConfigInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.ServletConfigInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.ServletConfigInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.ServletConfigInterceptor %}
-~~~~~~~

--- a/source/core-developers/static-parameters-interceptor.md
+++ b/source/core-developers/static-parameters-interceptor.md
@@ -7,30 +7,22 @@ title: Static Parameters Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.StaticParametersInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.StaticParametersInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.StaticParametersInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.StaticParametersInterceptor %}
-~~~~~~~

--- a/source/core-developers/string-length-field-validator-annotation.md
+++ b/source/core-developers/string-length-field-validator-annotation.md
@@ -7,30 +7,22 @@ title: StringLengthFieldValidator Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator %}
-~~~~~~~

--- a/source/core-developers/timer-interceptor.md
+++ b/source/core-developers/timer-interceptor.md
@@ -7,30 +7,22 @@ title: Timer Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.interceptor.TimerInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.interceptor.TimerInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.interceptor.TimerInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.interceptor.TimerInterceptor %}
-~~~~~~~

--- a/source/core-developers/token-interceptor.md
+++ b/source/core-developers/token-interceptor.md
@@ -7,31 +7,23 @@ title: Token Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.TokenInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.TokenInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.TokenInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.TokenInterceptor %}
-~~~~~~~
 

--- a/source/core-developers/token-session-interceptor.md
+++ b/source/core-developers/token-session-interceptor.md
@@ -7,30 +7,22 @@ title: Token Session Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.interceptor.TokenSessionStoreInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=org.apache.struts2.interceptor.TokenSessionStoreInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=org.apache.struts2.interceptor.TokenSessionStoreInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.interceptor.TokenSessionStoreInterceptor %}
-~~~~~~~

--- a/source/core-developers/type-conversion-annotation.md
+++ b/source/core-developers/type-conversion-annotation.md
@@ -7,30 +7,22 @@ title: TypeConversion Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.TypeConversion %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.TypeConversion %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.conversion.annotations.TypeConversion %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.conversion.annotations.TypeConversion %}
-~~~~~~~

--- a/source/core-developers/using-field-validators.md
+++ b/source/core-developers/using-field-validators.md
@@ -13,22 +13,16 @@ __Step 1__
 
 Create the jsp page
 
-~~~~~~~
 {% snippet id=fieldValidatorsExample|lang=xml|javadoc=false|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/fieldValidatorsExample.jsp %}
-~~~~~~~
 
 __Step 2__
 
 Create the action class
 
-~~~~~~~
 {% snippet id=fieldValidatorsExample|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/FieldValidatorsExampleAction.java %}
-~~~~~~~
 
 __Step 3__
 
 Create the validator\.xml\.
 
-~~~~~~~
 {% snippet id=fieldValidatorsExample|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/FieldValidatorsExampleAction-submitFieldValidatorsExamples-validation.xml %}
-~~~~~~~

--- a/source/core-developers/using-non-field-validators.md
+++ b/source/core-developers/using-non-field-validators.md
@@ -13,22 +13,16 @@ __Step 1__
 
 Create the jsp page
 
-~~~~~~~
 {% snippet id=nonFieldValidatorsExample|lang=xml|javadoc=false|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/nonFieldValidatorsExample.jsp %}
-~~~~~~~
 
 __Step 2__
 
 Create the action class
 
-~~~~~~~
 {% snippet id=nonFieldValidatorsExample|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/NonFieldValidatorsExampleAction.java %}
-~~~~~~~
 
 __Step 3__
 
 Create the validator\.xml\.
 
-~~~~~~~
 {% snippet id=nonFieldValidatorsExample|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/NonFieldValidatorsExampleAction-submitNonFieldValidatorsExamples-validation.xml %}
-~~~~~~~

--- a/source/core-developers/using-visitor-field-validator.md
+++ b/source/core-developers/using-visitor-field-validator.md
@@ -13,22 +13,16 @@ __Step 1__
 
 Create the jsp page\.
 
-~~~~~~~
 {% snippet id=visitorValidatorsExample|lang=xml|javadoc=false|url=struts2/apps/showcase/src/main/webapp/WEB-INF/validation/visitorValidatorsExample.jsp %}
-~~~~~~~
 
 __Step 2__
 
 Create the action class\.
 
-~~~~~~~
 {% snippet id=visitorValidatorsExample|javadoc=false|lang=java|url=struts2/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/VisitorValidatorsExampleAction.java %}
-~~~~~~~
 
 __Step 3__
 
 Create the validator\.xml\.
 
-~~~~~~~
 {% snippet id=visitorValidatorsExample|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/VisitorValidatorsExampleAction-submitVisitorValidatorsExamples-validation.xml %}
-~~~~~~~

--- a/source/core-developers/validation-annotation.md
+++ b/source/core-developers/validation-annotation.md
@@ -7,25 +7,19 @@ title: Validation Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validation %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validation %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validation %}
-~~~~~~~
 
 #####Examples#####
 
@@ -37,16 +31,12 @@ title: Validation Annotation
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.Validation %}
-~~~~~~~
 
 **An Annotated Class**
 
 
-~~~~~~~
 {% snippet id=example2|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.Validation %}
-~~~~~~~
 
 
 > 

--- a/source/core-developers/validation-interceptor.md
+++ b/source/core-developers/validation-interceptor.md
@@ -7,30 +7,22 @@ title: Validation Interceptor
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.ValidationInterceptor %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.ValidationInterceptor %}
-~~~~~~~
 
 #####Extending the Interceptor#####
 
 
 
-~~~~~~~
 {% snippet id=extending|javadoc=true|url=com.opensymphony.xwork2.validator.ValidationInterceptor %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=com.opensymphony.xwork2.validator.ValidationInterceptor %}
-~~~~~~~

--- a/source/core-developers/validation-parameter-annotation.md
+++ b/source/core-developers/validation-parameter-annotation.md
@@ -6,30 +6,22 @@ title: ValidationParameter annotation
 # ValidationParameter annotation
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ValidationParameter %}
-~~~~~~~
 
 __Usage__
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ValidationParameter %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.ValidationParameter %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.ValidationParameter %}
-~~~~~~~

--- a/source/core-developers/validations-annotation.md
+++ b/source/core-developers/validations-annotation.md
@@ -6,33 +6,25 @@ title: Validations Annotation
 # Validations Annotation
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validations %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validations %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.Validations %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.Validations %}
-~~~~~~~
 
 #####Different validations per method#####
 

--- a/source/core-developers/velocity-result.md
+++ b/source/core-developers/velocity-result.md
@@ -7,22 +7,16 @@ title: Velocity Result
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.dispatcher.VelocityResult %}
-~~~~~~~
 
 ####Parameters####
 
 
 
-~~~~~~~
 {% snippet id=params|javadoc=true|url=org.apache.struts2.dispatcher.VelocityResult %}
-~~~~~~~
 
 ####Examples####
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.dispatcher.VelocityResult %}
-~~~~~~~

--- a/source/core-developers/visitor-field-validator-annotation.md
+++ b/source/core-developers/visitor-field-validator-annotation.md
@@ -7,30 +7,22 @@ title: VisitorFieldValidator Annotation
 
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.VisitorFieldValidator %}
-~~~~~~~
 
 #####Usage#####
 
 
 
-~~~~~~~
 {% snippet id=usage|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.VisitorFieldValidator %}
-~~~~~~~
 
 #####Parameters#####
 
 
 
-~~~~~~~
 {% snippet id=parameters|javadoc=true|url=com.opensymphony.xwork2.validator.annotations.VisitorFieldValidator %}
-~~~~~~~
 
 #####Examples#####
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=java|url=com.opensymphony.xwork2.validator.annotations.VisitorFieldValidator %}
-~~~~~~~

--- a/source/tag-developers/action-tag.md
+++ b/source/tag-developers/action-tag.md
@@ -9,9 +9,7 @@ Please make sure you have read the [Tag Syntax](tag-syntax.html) document and un
 
 ## Description
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ActionComponent %}
-~~~~~~~
 
 Parameters can be passed to the action using nested [param](param-tag.html) tags.
 
@@ -39,16 +37,10 @@ Is "myAction" null outside the tag? false
 
 ## Examples
 
-~~~~~~~
 {% snippet id=javacode|javadoc=true|lang=java|url=org.apache.struts2.components.ActionComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=strutsxml|javadoc=true|lang=xml|url=org.apache.struts2.components.ActionComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.ActionComponent %}
-~~~~~~~

--- a/source/tag-developers/actionerror-tag.md
+++ b/source/tag-developers/actionerror-tag.md
@@ -7,18 +7,12 @@ title: Tag Developers Guide (WIP)
 
 ## Description
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ActionError %}
-~~~~~~~
 
 ## Parameters
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/actionerror.html %}
-~~~~~~~
 
 ## Examples
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ActionError %}
-~~~~~~~

--- a/source/tag-developers/actionmessage-tag.md
+++ b/source/tag-developers/actionmessage-tag.md
@@ -9,22 +9,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ActionMessage %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/actionmessage.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ActionMessage %}
-~~~~~~~

--- a/source/tag-developers/ajax-common-header.md
+++ b/source/tag-developers/ajax-common-header.md
@@ -20,82 +20,60 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/autocompleter.html %}
-~~~~~~~
 
 __Examples__
 
 Get list from an action:
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Uses a list:
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Autocompleter that reloads its content everytime the text changes (and the length of the text is greater than 3):
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Linking two autocompleters:
 
 
-~~~~~~~
 {% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Set/Get selected values using JavaScript:
 
 
-~~~~~~~
 {% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Using beforeNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Using errorNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example7|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Using errorNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example8|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Using valueNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example9|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 __Caveats__
 
@@ -114,9 +92,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 
 There's a bug in  IE6/IE7 which makes impossible to use the target's attribute with a parent Div, because such Div's content's are overwritten with the tag's _loadingText_ . Resulting in an "undefined" message in the content's, instead of the result of the request.
 
@@ -139,53 +115,39 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/bind.html %}
-~~~~~~~
 
 __Examples__
 
 Without attaching to an event, listening to a topic (used to make an Ajax call):
 
 
-~~~~~~~
 {% snippet id=example0|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 
 Attached to event 'onclick' on submit button:
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 
 Submit form:
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 
 Using beforeNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 
 Using afterNotifyTopics and highlight:
 
 
-~~~~~~~
 {% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 
 Using errorNotifyTopics and indicator:
 
 
-~~~~~~~
 {% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 
 #####checkbox##### {#PAGE_14029}
 
@@ -198,25 +160,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Checkbox %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/checkbox.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Checkbox %}
-~~~~~~~
 
 #####checkboxlist##### {#PAGE_13969}
 
@@ -232,25 +188,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.CheckboxList %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/checkboxlist.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.CheckboxList %}
-~~~~~~~
 
 #####combobox##### {#PAGE_14259}
 
@@ -263,25 +213,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ComboBox %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/combobox.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ComboBox %}
-~~~~~~~
 
 #####component##### {#PAGE_14033}
 
@@ -289,9 +233,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.GenericUIBean %}
-~~~~~~~
 
 {% snippet id=note|javadoc=true|url=org.apache.struts2.components.GenericUIBean %}
 
@@ -316,17 +258,13 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/component.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.GenericUIBean %}
-~~~~~~~
 
 #####datetextfield##### {#PAGE_40506485}
 
@@ -339,25 +277,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.DateTextField %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/datetextfield.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.DateTextField %}
-~~~~~~~
 
 #####datetimepicker##### {#PAGE_14274}
 
@@ -365,39 +297,29 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/datetimepicker.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
-~~~~~~~
 
 Getting and getting the datetimepicker value, from JavaScript:
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
-~~~~~~~
 
 Publish topic when value changes
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
-~~~~~~~
 
 #####div##### {#PAGE_13908}
 
@@ -405,9 +327,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Div %}
-~~~~~~~
 
 
 
@@ -419,9 +339,7 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/div.html %}
-~~~~~~~
 
 #####dojo div##### {#PAGE_66929}
 
@@ -429,40 +347,30 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/div.html %}
-~~~~~~~
 
 __Examples__
 
 Simple div that loads its content once:
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
-~~~~~~~
 
 div that reloads its content every 2 seconds, and shows an indicator while reloading:
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
-~~~~~~~
 
 div that uses topics to control the timer, highlights its content in red after reload, and submits a form:
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
-~~~~~~~
 
 #####dojo head##### {#PAGE_66757}
 
@@ -473,9 +381,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
-~~~~~~~
 
 
 > 
@@ -490,22 +396,16 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/head.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
-~~~~~~~
 
 #####dojo textarea##### {#PAGE_66931}
 
@@ -513,17 +413,13 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TextArea.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/textarea.html %}
-~~~~~~~
 
 #####doubleselect##### {#PAGE_14005}
 
@@ -539,25 +435,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleSelect %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/doubleselect.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.DoubleSelect %}
-~~~~~~~
 
 #####fielderror##### {#PAGE_14151}
 
@@ -565,30 +455,22 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.FieldError %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/fielderror.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.FieldError %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.components.FieldError %}
-~~~~~~~
 
 #####file##### {#PAGE_14283}
 
@@ -601,25 +483,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.File %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/file.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.File %}
-~~~~~~~
 
 #####form##### {#PAGE_14201}
 
@@ -632,25 +508,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Form %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/form.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Form %}
-~~~~~~~
 
 __Validation__
 
@@ -667,25 +537,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Head %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/head.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=org.apache.struts2.components.Head %}
-~~~~~~~
 
 #####hidden##### {#PAGE_14313}
 
@@ -698,25 +562,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Hidden %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/hidden.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Hidden %}
-~~~~~~~
 
 #####inputtransferselect##### {#PAGE_17268774}
 
@@ -724,9 +582,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.InputTransferSelect %}
-~~~~~~~
 
 {% snippet id=notice|javadoc=true|url=org.apache.struts2.components.InputTransferSelect %}
 
@@ -734,17 +590,13 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/inputtransferselect.html %}
-~~~~~~~
 
 __Example__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.InputTransferSelect %}
-~~~~~~~
 
 #####label##### {#PAGE_14167}
 
@@ -757,30 +609,22 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Label %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/label.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Label %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.Label %}
-~~~~~~~
 
 #####optgroup##### {#PAGE_14170}
 
@@ -793,9 +637,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.OptGroup %}
-~~~~~~~
 
 {% snippet id=notice|javadoc=true|url=org.apache.struts2.components.OptGroup %}
 
@@ -803,17 +645,13 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/optgroup.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.OptGroup %}
-~~~~~~~
 
 #####optiontransferselect##### {#PAGE_13943}
 
@@ -829,30 +667,22 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=notice|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/optiontransferselect.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect %}
-~~~~~~~
 
 #####password##### {#PAGE_13826}
 
@@ -865,30 +695,22 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Password %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/password.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=exdescription|javadoc=true|lang=none|url=org.apache.struts2.components.Password %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Password %}
-~~~~~~~
 
 #####radio##### {#PAGE_14226}
 
@@ -904,35 +726,25 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Radio %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/radio.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=exdescription|javadoc=true|url=org.apache.struts2.components.Radio %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Radio %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example_fmt|javadoc=true|lang=xml|url=org.apache.struts2.components.Radio %}
-~~~~~~~
 
 #####reset##### {#PAGE_13833}
 
@@ -945,17 +757,13 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Reset %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/reset.html %}
-~~~~~~~
 
 __Examples__
 
@@ -963,17 +771,13 @@ __Example 1__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Reset %}
-~~~~~~~
 
 __Example 2__
 
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=org.apache.struts2.components.Reset %}
-~~~~~~~
 
 #####select##### {#PAGE_14127}
 
@@ -986,30 +790,22 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Select %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/select.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=exnote|javadoc=true|lang=none|url=org.apache.struts2.components.Select %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Select %}
-~~~~~~~
 
 #####submit##### {#PAGE_14054}
 
@@ -1022,9 +818,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Submit %}
-~~~~~~~
 
 
 
@@ -1041,9 +835,7 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/submit.html %}
-~~~~~~~
 
 #####tabbedPanel##### {#PAGE_14222}
 
@@ -1051,33 +843,25 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/a.html %}
-~~~~~~~
 
 __Examples__
 
 The following is an example of a tabbedpanel and panel tag utilizing local and remote content:
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java %}
-~~~~~~~
 
 Use notify topics to prevent a tab from being selected:
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java %}
-~~~~~~~
 
 #####textarea##### {#PAGE_13926}
 
@@ -1090,25 +874,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.TextArea %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/textarea.html %}
-~~~~~~~
 
 __Example__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.TextArea %}
-~~~~~~~
 
 #####textfield##### {#PAGE_13912}
 
@@ -1121,30 +899,22 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.TextField %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/textfield.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.TextField %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.TextField %}
-~~~~~~~
 
 #####token##### {#PAGE_13998}
 
@@ -1157,25 +927,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Token %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/token.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Token %}
-~~~~~~~
 
 #####tree##### {#PAGE_14168}
 
@@ -1183,40 +947,30 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/tree.html %}
-~~~~~~~
 
 __Examples__
 
 Static tree:
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
-~~~~~~~
 
 Dynamic tree (rendered on the server):
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
-~~~~~~~
 
 Dynamic tree loaded with AJAX (one request is made for each node):
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
-~~~~~~~
 
 #####treenode##### {#PAGE_14288}
 
@@ -1224,26 +978,20 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TreeNode.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/treenode.html %}
-~~~~~~~
 
 __Examples__
 
 Update target content with html returned from an action:
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TreeNode.java %}
-~~~~~~~
 
 #####updownselect##### {#PAGE_13884}
 
@@ -1259,25 +1007,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.UpDownSelect %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/updownselect.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.UpDownSelect %}
-~~~~~~~
 
 ####dojo anchor#### {#PAGE_66791}
 
@@ -1285,9 +1027,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~
 
 There's a bug in  IE6/IE7 which makes impossible to use the target's attribute with a parent Div, because such Div's content's are overwritten with the tag's _loadingText_ . Resulting in an "undefined" message in the content's, instead of the result of the request.
 
@@ -1309,53 +1049,39 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/a.html %}
-~~~~~~~
 
 __Examples__
 
 Update target content with html returned from an action:
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~
 
 Submit form(anchor inside the form):
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~
 
 Submit form(anchor outside the form):
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~
 
 Using beforeNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~
 
 Using afterNotifyTopics and highlights target:
 
 
-~~~~~~~
 {% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~
 
 Using errorNotifyTopics and indicator:
 
 
-~~~~~~~
 {% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~
 
 ####dojo submit#### {#PAGE_66801}
 
@@ -1363,9 +1089,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 There's a bug in  IE6/IE7 which makes impossible to use the target's attribute with a parent Div, because such Div's content's are overwritten with the tag's _loadingText_ . Resulting in an "undefined" message in the content's, instead of the result of the request.
 
@@ -1387,71 +1111,51 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/submit.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Render an image submit:
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Render a button submit:
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Update target content with html returned from an action:
 
 
-~~~~~~~
 {% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Submit form(inside the form):
 
 
-~~~~~~~
 {% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Submit form(outside the form):
 
 
-~~~~~~~
 {% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Using beforeNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example7|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Using afterNotifyTopics and highlight target:
 
 
-~~~~~~~
 {% snippet id=example8|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Using errorNotifyTopics and indicator:
 
 
-~~~~~~~
 {% snippet id=example9|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 

--- a/source/tag-developers/append-tag.md
+++ b/source/tag-developers/append-tag.md
@@ -9,22 +9,14 @@ Please make sure you have read the [Tag Syntax](tag-syntax.html) document and un
 
 ## Description
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.AppendIterator %}
-~~~~~~~
 
 ## Parameters
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/append.html %}
-~~~~~~~
 
 ## Example
 
-~~~~~~~
 {% snippet id=code|lang=java|javadoc=true|url=org.apache.struts2.components.AppendIterator %}
-~~~~~~~
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.AppendIterator %}
-~~~~~~~

--- a/source/tag-developers/bean-tag.md
+++ b/source/tag-developers/bean-tag.md
@@ -9,22 +9,14 @@ Please make sure you have read the [Tag Syntax](tag-syntax.html) document and un
 
 ## Description
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Bean %}
-~~~~~~~
 
 ## Parameters
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/bean.html %}
-~~~~~~~
 
 ## Examples
 
-~~~~~~~
 {% snippet id=examples|javadoc=true|lang=xml|url=org.apache.struts2.components.Bean %}
-~~~~~~~
 
-~~~~~~~
 {% snippet id=examplesdescription|javadoc=true|url=org.apache.struts2.components.Bean %}
-~~~~~~~

--- a/source/tag-developers/checkbox-tag.md
+++ b/source/tag-developers/checkbox-tag.md
@@ -14,22 +14,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Checkbox %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/checkbox.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Checkbox %}
-~~~~~~~

--- a/source/tag-developers/checkboxlist-tag.md
+++ b/source/tag-developers/checkboxlist-tag.md
@@ -17,22 +17,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.CheckboxList %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/checkboxlist.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.CheckboxList %}
-~~~~~~~

--- a/source/tag-developers/combobox-tag.md
+++ b/source/tag-developers/combobox-tag.md
@@ -14,22 +14,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ComboBox %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/combobox.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ComboBox %}
-~~~~~~~

--- a/source/tag-developers/component-tag.md
+++ b/source/tag-developers/component-tag.md
@@ -8,9 +8,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.GenericUIBean %}
-~~~~~~~
 
 {% snippet id=note|javadoc=true|url=org.apache.struts2.components.GenericUIBean %}
 
@@ -35,14 +33,10 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/component.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.GenericUIBean %}
-~~~~~~~

--- a/source/tag-developers/date-tag.md
+++ b/source/tag-developers/date-tag.md
@@ -9,22 +9,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Date %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/date.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Date %}
-~~~~~~~

--- a/source/tag-developers/datetextfield-tag.md
+++ b/source/tag-developers/datetextfield-tag.md
@@ -14,22 +14,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.DateTextField %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/datetextfield.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.DateTextField %}
-~~~~~~~

--- a/source/tag-developers/div-tag.md
+++ b/source/tag-developers/div-tag.md
@@ -9,9 +9,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Div %}
-~~~~~~~
 
 
 
@@ -23,6 +21,4 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/div.html %}
-~~~~~~~

--- a/source/tag-developers/dojo-a-tag.md
+++ b/source/tag-developers/dojo-a-tag.md
@@ -9,9 +9,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~
 
 There's a bug in  IE6/IE7 which makes impossible to use the target's attribute with a parent Div, because such Div's content's are overwritten with the tag's _loadingText_ . Resulting in an "undefined" message in the content's, instead of the result of the request.
 
@@ -33,50 +31,36 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/a.html %}
-~~~~~~~
 
 __Examples__
 
 Update target content with html returned from an action:
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~
 
 Submit form(anchor inside the form):
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~
 
 Submit form(anchor outside the form):
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~
 
 Using beforeNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~
 
 Using afterNotifyTopics and highlights target:
 
 
-~~~~~~~
 {% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~
 
 Using errorNotifyTopics and indicator:
 
 
-~~~~~~~
 {% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Anchor.java %}
-~~~~~~~

--- a/source/tag-developers/dojo-autocompleter-tag.md
+++ b/source/tag-developers/dojo-autocompleter-tag.md
@@ -9,82 +9,60 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/autocompleter.html %}
-~~~~~~~
 
 __Examples__
 
 Get list from an action:
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Uses a list:
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Autocompleter that reloads its content everytime the text changes (and the length of the text is greater than 3):
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Linking two autocompleters:
 
 
-~~~~~~~
 {% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Set/Get selected values using JavaScript:
 
 
-~~~~~~~
 {% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Using beforeNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Using errorNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example7|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Using errorNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example8|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 Using valueNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example9|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
-~~~~~~~
 
 __Caveats__
 

--- a/source/tag-developers/dojo-bind-tag.md
+++ b/source/tag-developers/dojo-bind-tag.md
@@ -9,9 +9,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 
 There's a bug in  IE6/IE7 which makes impossible to use the target's attribute with a parent Div, because such Div's content's are overwritten with the tag's _loadingText_ . Resulting in an "undefined" message in the content's, instead of the result of the request.
 
@@ -34,51 +32,37 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/bind.html %}
-~~~~~~~
 
 __Examples__
 
 Without attaching to an event, listening to a topic (used to make an Ajax call):
 
 
-~~~~~~~
 {% snippet id=example0|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 
 Attached to event 'onclick' on submit button:
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 
 Submit form:
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 
 Using beforeNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 
 Using afterNotifyTopics and highlight:
 
 
-~~~~~~~
 {% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 
 Using errorNotifyTopics and indicator:
 
 
-~~~~~~~
 {% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Bind.java %}
-~~~~~~~
 

--- a/source/tag-developers/dojo-datetimepicker-tag.md
+++ b/source/tag-developers/dojo-datetimepicker-tag.md
@@ -9,36 +9,26 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/datetimepicker.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
-~~~~~~~
 
 Getting and getting the datetimepicker value, from JavaScript:
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
-~~~~~~~
 
 Publish topic when value changes
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/DateTimePicker.java %}
-~~~~~~~

--- a/source/tag-developers/dojo-div-tag.md
+++ b/source/tag-developers/dojo-div-tag.md
@@ -9,37 +9,27 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/div.html %}
-~~~~~~~
 
 __Examples__
 
 Simple div that loads its content once:
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
-~~~~~~~
 
 div that reloads its content every 2 seconds, and shows an indicator while reloading:
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
-~~~~~~~
 
 div that uses topics to control the timer, highlights its content in red after reload, and submits a form:
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Div.java %}
-~~~~~~~

--- a/source/tag-developers/dojo-head-tag.md
+++ b/source/tag-developers/dojo-head-tag.md
@@ -12,9 +12,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
-~~~~~~~
 
 
 > 
@@ -29,19 +27,13 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/head.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Head.java %}
-~~~~~~~

--- a/source/tag-developers/dojo-submit-tag.md
+++ b/source/tag-developers/dojo-submit-tag.md
@@ -9,9 +9,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 There's a bug in  IE6/IE7 which makes impossible to use the target's attribute with a parent Div, because such Div's content's are overwritten with the tag's _loadingText_ . Resulting in an "undefined" message in the content's, instead of the result of the request.
 
@@ -33,71 +31,51 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/submit.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Render an image submit:
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Render a button submit:
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Update target content with html returned from an action:
 
 
-~~~~~~~
 {% snippet id=example4|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Submit form(inside the form):
 
 
-~~~~~~~
 {% snippet id=example5|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Submit form(outside the form):
 
 
-~~~~~~~
 {% snippet id=example6|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Using beforeNotifyTopics:
 
 
-~~~~~~~
 {% snippet id=example7|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Using afterNotifyTopics and highlight target:
 
 
-~~~~~~~
 {% snippet id=example8|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 
 Using errorNotifyTopics and indicator:
 
 
-~~~~~~~
 {% snippet id=example9|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Submit.java %}
-~~~~~~~
 

--- a/source/tag-developers/dojo-tabbedpanel-tag.md
+++ b/source/tag-developers/dojo-tabbedpanel-tag.md
@@ -9,30 +9,22 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/a.html %}
-~~~~~~~
 
 __Examples__
 
 The following is an example of a tabbedpanel and panel tag utilizing local and remote content:
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java %}
-~~~~~~~
 
 Use notify topics to prevent a tab from being selected:
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TabbedPanel.java %}
-~~~~~~~

--- a/source/tag-developers/dojo-textarea-tag.md
+++ b/source/tag-developers/dojo-textarea-tag.md
@@ -9,14 +9,10 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TextArea.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/textarea.html %}
-~~~~~~~

--- a/source/tag-developers/dojo-tree-tag.md
+++ b/source/tag-developers/dojo-tree-tag.md
@@ -9,37 +9,27 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/tree.html %}
-~~~~~~~
 
 __Examples__
 
 Static tree:
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
-~~~~~~~
 
 Dynamic tree (rendered on the server):
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
-~~~~~~~
 
 Dynamic tree loaded with AJAX (one request is made for each node):
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Tree.java %}
-~~~~~~~

--- a/source/tag-developers/dojo-treenode-tag.md
+++ b/source/tag-developers/dojo-treenode-tag.md
@@ -9,23 +9,17 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TreeNode.java %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/ajax/treenode.html %}
-~~~~~~~
 
 __Examples__
 
 Update target content with html returned from an action:
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/TreeNode.java %}
-~~~~~~~

--- a/source/tag-developers/doubleselect-tag.md
+++ b/source/tag-developers/doubleselect-tag.md
@@ -17,22 +17,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.DoubleSelect %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/doubleselect.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.DoubleSelect %}
-~~~~~~~

--- a/source/tag-developers/else-tag.md
+++ b/source/tag-developers/else-tag.md
@@ -14,22 +14,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Else %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/else.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Else %}
-~~~~~~~

--- a/source/tag-developers/elseif-tag.md
+++ b/source/tag-developers/elseif-tag.md
@@ -14,22 +14,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.ElseIf %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/elseif.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.ElseIf %}
-~~~~~~~

--- a/source/tag-developers/fielderror-tag.md
+++ b/source/tag-developers/fielderror-tag.md
@@ -9,27 +9,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.FieldError %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/fielderror.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.FieldError %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=description|javadoc=true|url=org.apache.struts2.components.FieldError %}
-~~~~~~~

--- a/source/tag-developers/file-tag.md
+++ b/source/tag-developers/file-tag.md
@@ -14,22 +14,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.File %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/file.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.File %}
-~~~~~~~

--- a/source/tag-developers/form-tag.md
+++ b/source/tag-developers/form-tag.md
@@ -14,25 +14,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Form %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/form.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Form %}
-~~~~~~~
 
 __Validation__
 

--- a/source/tag-developers/form-tags.md
+++ b/source/tag-developers/form-tags.md
@@ -62,33 +62,25 @@ __Template-Related Attributes__
 
 
 
-~~~~~~~
 {% snippet id=templateRelatedAttributes|javadoc=true|url=org.apache.struts2.components.UIBean %}
-~~~~~~~
 
 __Javascript-Related Attributes__
 
 
 
-~~~~~~~
 {% snippet id=javascriptRelatedAttributes|javadoc=true|url=org.apache.struts2.components.UIBean %}
-~~~~~~~
 
 __Tooltip Related Attributes__
 
 
 
-~~~~~~~
 {% snippet id=tooltipattributes|javadoc=true|url=org.apache.struts2.components.UIBean %}
-~~~~~~~
 
 __General Attributes__
 
 
 
-~~~~~~~
 {% snippet id=generalAttributes|javadoc=true|url=org.apache.struts2.components.UIBean %}
-~~~~~~~
 
 
 
@@ -254,11 +246,7 @@ __Tooltip__
 
 
 
-~~~~~~~
 {% snippet id=tooltipdescription|javadoc=true|url=org.apache.struts2.components.UIBean %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=tooltipexample|lang=xml|javadoc=true|url=org.apache.struts2.components.UIBean %}
-~~~~~~~

--- a/source/tag-developers/generator-tag.md
+++ b/source/tag-developers/generator-tag.md
@@ -9,22 +9,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.views.jsp.iterator.IteratorGeneratorTag %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/generator.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.IteratorGeneratorTag %}
-~~~~~~~

--- a/source/tag-developers/head-tag.md
+++ b/source/tag-developers/head-tag.md
@@ -14,22 +14,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Head %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/head.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=org.apache.struts2.components.Head %}
-~~~~~~~

--- a/source/tag-developers/hidden-tag.md
+++ b/source/tag-developers/hidden-tag.md
@@ -14,22 +14,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Hidden %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/hidden.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Hidden %}
-~~~~~~~

--- a/source/tag-developers/i18n-tag.md
+++ b/source/tag-developers/i18n-tag.md
@@ -14,22 +14,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.I18n %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/i18n.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.I18n %}
-~~~~~~~

--- a/source/tag-developers/if-tag.md
+++ b/source/tag-developers/if-tag.md
@@ -18,14 +18,10 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/if.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=struts2/core/src/main/java/org/apache/struts2/components/If.java %}
-~~~~~~~

--- a/source/tag-developers/include-tag.md
+++ b/source/tag-developers/include-tag.md
@@ -14,9 +14,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Include %}
-~~~~~~~
 
 **(!) How To access parameters**
 
@@ -33,19 +31,13 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/include.html %}
-~~~~~~~
 
 __Example__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=java|javadoc=true|url=org.apache.struts2.components.Include %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=exampledescription|lang=none|javadoc=true|url=org.apache.struts2.components.Include %}
-~~~~~~~

--- a/source/tag-developers/inputtransferselect-tag.md
+++ b/source/tag-developers/inputtransferselect-tag.md
@@ -9,9 +9,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.InputTransferSelect %}
-~~~~~~~
 
 {% snippet id=notice|javadoc=true|url=org.apache.struts2.components.InputTransferSelect %}
 
@@ -19,14 +17,10 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/inputtransferselect.html %}
-~~~~~~~
 
 __Example__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.InputTransferSelect %}
-~~~~~~~

--- a/source/tag-developers/iterator-tag.md
+++ b/source/tag-developers/iterator-tag.md
@@ -23,87 +23,55 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/iterator.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example1description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example1code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example2description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example2code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example3description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example3code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example4description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example4code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example5description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example5code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example6description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example6code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example7description|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example7code|lang=xml|javadoc=true|url=org.apache.struts2.components.IteratorComponent %}
-~~~~~~~

--- a/source/tag-developers/label-tag.md
+++ b/source/tag-developers/label-tag.md
@@ -14,27 +14,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Label %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/label.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Label %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.Label %}
-~~~~~~~

--- a/source/tag-developers/merge-tag.md
+++ b/source/tag-developers/merge-tag.md
@@ -14,27 +14,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.MergeIterator %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/merge.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=javacode|lang=java|javadoc=true|url=org.apache.struts2.components.MergeIterator %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.MergeIterator %}
-~~~~~~~

--- a/source/tag-developers/optgroup-tag.md
+++ b/source/tag-developers/optgroup-tag.md
@@ -14,9 +14,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.OptGroup %}
-~~~~~~~
 
 {% snippet id=notice|javadoc=true|url=org.apache.struts2.components.OptGroup %}
 
@@ -24,14 +22,10 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/optgroup.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.OptGroup %}
-~~~~~~~

--- a/source/tag-developers/optiontransferselect-tag.md
+++ b/source/tag-developers/optiontransferselect-tag.md
@@ -17,27 +17,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=notice|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/optiontransferselect.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.OptionTransferSelect %}
-~~~~~~~

--- a/source/tag-developers/param-tag.md
+++ b/source/tag-developers/param-tag.md
@@ -14,27 +14,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Param %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/param.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Param %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=exampledescription|javadoc=true|url=org.apache.struts2.components.Param %}
-~~~~~~~

--- a/source/tag-developers/password-tag.md
+++ b/source/tag-developers/password-tag.md
@@ -14,27 +14,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Password %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/password.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=exdescription|javadoc=true|lang=none|url=org.apache.struts2.components.Password %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Password %}
-~~~~~~~

--- a/source/tag-developers/property-tag.md
+++ b/source/tag-developers/property-tag.md
@@ -14,27 +14,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Property %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/property.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Property %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=exampledescription|lang=none|javadoc=true|url=org.apache.struts2.components.Property %}
-~~~~~~~

--- a/source/tag-developers/push-tag.md
+++ b/source/tag-developers/push-tag.md
@@ -14,57 +14,37 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Push %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/push.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=org.apache.struts2.components.Push %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example1description|lang=none|javadoc=true|url=org.apache.struts2.components.Push %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=org.apache.struts2.components.Push %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example2description|lang=none|javadoc=true|url=org.apache.struts2.components.Push %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=org.apache.struts2.components.Push %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example3description|lang=none|javadoc=true|url=org.apache.struts2.components.Push %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example4|lang=xml|javadoc=true|url=org.apache.struts2.components.Push %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example4description|lang=none|javadoc=true|url=org.apache.struts2.components.Push %}
-~~~~~~~

--- a/source/tag-developers/radio-tag.md
+++ b/source/tag-developers/radio-tag.md
@@ -17,32 +17,22 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Radio %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/radio.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=exdescription|javadoc=true|url=org.apache.struts2.components.Radio %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Radio %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example_fmt|javadoc=true|lang=xml|url=org.apache.struts2.components.Radio %}
-~~~~~~~

--- a/source/tag-developers/reset-tag.md
+++ b/source/tag-developers/reset-tag.md
@@ -14,17 +14,13 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Reset %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/reset.html %}
-~~~~~~~
 
 __Examples__
 
@@ -32,14 +28,10 @@ __Example 1__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Reset %}
-~~~~~~~
 
 __Example 2__
 
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=org.apache.struts2.components.Reset %}
-~~~~~~~

--- a/source/tag-developers/select-tag.md
+++ b/source/tag-developers/select-tag.md
@@ -14,27 +14,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Select %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/select.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=exnote|javadoc=true|lang=none|url=org.apache.struts2.components.Select %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Select %}
-~~~~~~~

--- a/source/tag-developers/set-tag.md
+++ b/source/tag-developers/set-tag.md
@@ -14,22 +14,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Set %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/set.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Set %}
-~~~~~~~

--- a/source/tag-developers/sort-tag.md
+++ b/source/tag-developers/sort-tag.md
@@ -14,22 +14,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SortIteratorTag %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|url=struts2-tags/sort.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SortIteratorTag %}
-~~~~~~~

--- a/source/tag-developers/submit-tag.md
+++ b/source/tag-developers/submit-tag.md
@@ -14,9 +14,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Submit %}
-~~~~~~~
 
 
 
@@ -33,6 +31,4 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/submit.html %}
-~~~~~~~

--- a/source/tag-developers/subset-tag.md
+++ b/source/tag-developers/subset-tag.md
@@ -9,47 +9,31 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/subset.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=action|lang=java|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example1|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example2|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example3|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example4|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example5|lang=xml|javadoc=true|url=org.apache.struts2.views.jsp.iterator.SubsetIteratorTag %}
-~~~~~~~

--- a/source/tag-developers/text-tag.md
+++ b/source/tag-developers/text-tag.md
@@ -13,9 +13,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Text %}
-~~~~~~~
 
 For more details on using resource bundles with Struts 2 read the _localization guide_ .
 
@@ -23,22 +21,16 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/text.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.Text %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.Text %}
-~~~~~~~
 
 Other example
 

--- a/source/tag-developers/textarea-tag.md
+++ b/source/tag-developers/textarea-tag.md
@@ -14,22 +14,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.TextArea %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/textarea.html %}
-~~~~~~~
 
 __Example__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.TextArea %}
-~~~~~~~

--- a/source/tag-developers/textfield-tag.md
+++ b/source/tag-developers/textfield-tag.md
@@ -14,27 +14,19 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.TextField %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/textfield.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=exdescription|lang=none|javadoc=true|url=org.apache.struts2.components.TextField %}
-~~~~~~~
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.TextField %}
-~~~~~~~

--- a/source/tag-developers/token-tag.md
+++ b/source/tag-developers/token-tag.md
@@ -14,22 +14,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Token %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/token.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|javadoc=true|lang=xml|url=org.apache.struts2.components.Token %}
-~~~~~~~

--- a/source/tag-developers/updownselect-tag.md
+++ b/source/tag-developers/updownselect-tag.md
@@ -17,22 +17,16 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.UpDownSelect %}
-~~~~~~~
 
 __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/updownselect.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.UpDownSelect %}
-~~~~~~~

--- a/source/tag-developers/url-tag.md
+++ b/source/tag-developers/url-tag.md
@@ -19,9 +19,7 @@ __Description__
 
 
 
-~~~~~~~
 {% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.URL %}
-~~~~~~~
 
 __Setting a default value for includeParams__
 
@@ -55,14 +53,10 @@ __Parameters__
 
 
 
-~~~~~~~
 {% snippet id=tagattributes|javadoc=false|url=struts2-tags/url.html %}
-~~~~~~~
 
 __Examples__
 
 
 
-~~~~~~~
 {% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.components.URL %}
-~~~~~~~


### PR DESCRIPTION
# Changes
+ Supports snippets with base path `struts2/` and `struts2-tags/`
+ Caches fetched contents in files
+ Prints to `STDERR` on snippet loading failure but continue to next
+ Deletes `~~~~~~` before and after snippet (a RegEx replace)

# Test results

All snippets successfully loaded and generated except all `dojo` snippets and followings:

```text
START SNIPPET: javadoc not found in https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/components/DateTextField.java;hb=HEAD
START SNIPPET: example not found in https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/components/DateTextField.java;hb=HEAD
START SNIPPET: javadoc not found in https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/components/Div.java;hb=HEAD
START SNIPPET: javadoc not found in https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/components/DateTextField.java;hb=HEAD
START SNIPPET: example not found in https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/components/DateTextField.java;hb=HEAD
START SNIPPET: javadoc not found in https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/components/Div.java;hb=HEAD
START SNIPPET: description not found in https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/dispatcher/PostbackResult.java;hb=HEAD
START SNIPPET: params not found in https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/dispatcher/PostbackResult.java;hb=HEAD
START SNIPPET: example not found in https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/dispatcher/PostbackResult.java;hb=HEAD
START SNIPPET: visitorValidatorsExample not found in https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/VisitorValidatorsExampleAction-submitVisitorValidatorsExamples-validation.xml;hb=HEAD
START SNIPPET: description not found in https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/dispatcher/VelocityResult.java;hb=HEAD
START SNIPPET: params not found in https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/dispatcher/VelocityResult.java;hb=HEAD
START SNIPPET: example not found in https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/dispatcher/VelocityResult.java;hb=HEAD
```