### PR TITLE
Deletes lang=html as it is default

### DIFF
--- a/source/plugins/plugins.md
+++ b/source/plugins/plugins.md
@@ -51,7 +51,7 @@ Extension points allow a plugin to override a key class in the Struts framework 
 
 The following extension points are available in Struts 2:
 
-{% snippet id=extensionPoints|lang=html|javadoc=true|org.apache.struts2.config.DefaultBeanSelectionProvider %}
+{% snippet id=extensionPoints|javadoc=true|org.apache.struts2.config.DefaultBeanSelectionProvider %}
 
 ## Plugin Examples
 

--- a/source/tag-developers/ajax-common-header.md
+++ b/source/tag-developers/ajax-common-header.md
@@ -68,12 +68,12 @@ Using errorNotifyTopics:
 Using errorNotifyTopics:
 
 
-{% snippet id=example8|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
+{% snippet id=example8|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 
 Using valueNotifyTopics:
 
 
-{% snippet id=example9|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
+{% snippet id=example9|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 
 __Caveats__
 

--- a/source/tag-developers/dojo-autocompleter-tag.md
+++ b/source/tag-developers/dojo-autocompleter-tag.md
@@ -57,12 +57,12 @@ Using errorNotifyTopics:
 Using errorNotifyTopics:
 
 
-{% snippet id=example8|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
+{% snippet id=example8|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 
 Using valueNotifyTopics:
 
 
-{% snippet id=example9|lang=html|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
+{% snippet id=example9|javadoc=true|url=struts2/plugins/dojo/src/main/java/org/apache/struts2/dojo/components/Autocompleter.java %}
 
 __Caveats__
 


### PR DESCRIPTION
I keep html lang as an option in `snippet.rb` while someone may want to really display an html inside a block.