### PR TITLE
Fixes missing snippets with fetched contents

### DIFF
--- a/source/core-developers/postback-result.md
+++ b/source/core-developers/postback-result.md
@@ -9,16 +9,75 @@ title: Postback Result
 
 
 
-{% snippet id=description|javadoc=true|url=org.apache.struts2.dispatcher.PostbackResult %}
+{% comment %}start snippet id=description|javadoc=true|url=org.apache.struts2.result.PostbackResult {% endcomment %}
+<p> <p>
+
+ A result that renders the current request parameters as a form which
+
+ immediately submits a <a href="http://en.wikipedia.org/wiki/Postback">postback</a>
+
+ to the specified destination.
+
+ </p>
+</p>
+{% comment %}end snippet id=description|javadoc=true|url=org.apache.struts2.result.PostbackResult {% endcomment %}
 
 ####Parameters####
 
 
 
-{% snippet id=params|javadoc=true|url=org.apache.struts2.dispatcher.PostbackResult %}
+{% comment %}start snippet id=params|javadoc=true|url=org.apache.struts2.result.PostbackResult {% endcomment %}
+<p> <ul>
+
+     <li>location - http location to post the form</li>
+
+     <li>prependServletContext (true|false) -  when location is relative, controls if to add Servlet Context, default "true"</li>
+
+     <li>actionName - action name to post the form (resolved as an expression)</li>
+
+     <li>namespace - action's namespace to use (resolved as an expression)</li>
+
+     <li>method - actions' method to use (resolved as an expression)</li>
+
+     <li>cache (true|false) - when set to true adds cache control headers, default "true"</li>
+
+     <li>parse (true|false) - when set to true actionName, namespace and method are parsed, default "true"</li>
+
+ </ul>
+</p>
+{% comment %}end snippet id=params|javadoc=true|url=org.apache.struts2.result.PostbackResult {% endcomment %}
 
 ####Examples####
 
 
 
-{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.dispatcher.PostbackResult %}
+{% comment %}start snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.result.PostbackResult {% endcomment %}
+
+
+```xml
+
+ <action name="registerThirdParty" >
+
+   <result type="postback">https://www.example.com/register</result>
+
+ </action>
+
+
+
+ <action name="registerThirdParty" >
+
+   <result type="postback">
+
+     <param name="namespace">/secure</param>
+
+     <param name="actionName">register2</param>
+
+   </result>
+
+ </action>
+
+
+```
+
+
+{% comment %}end snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.result.PostbackResult {% endcomment %}

--- a/source/core-developers/using-visitor-field-validator.md
+++ b/source/core-developers/using-visitor-field-validator.md
@@ -64,4 +64,35 @@ __Step 3__
 
 Create the validator\.xml\.
 
-{% snippet id=visitorValidatorsExample|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/VisitorValidatorsExampleAction-submitVisitorValidatorsExamples-validation.xml %}
+{% comment %}start snippet id=visitorValidatorsExample|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/VisitorValidatorsExampleAction-submitVisitorValidatorsExamples-validation.xml {% endcomment %}
+
+
+```xml
+
+
+
+<validators>
+
+	<field name="user">
+
+		<field-validator type="visitor">
+
+			<param name="context">userContext</param>
+
+			<param name="appendPrefix">true</param>
+
+			<message>User:</message>
+
+		</field-validator>
+
+	</field>
+
+</validators>
+
+
+
+
+```
+
+
+{% comment %}end snippet id=visitorValidatorsExample|javadoc=false|lang=xml|url=struts2/apps/showcase/src/main/resources/org/apache/struts2/showcase/validation/VisitorValidatorsExampleAction-submitVisitorValidatorsExamples-validation.xml {% endcomment %}

--- a/source/core-developers/velocity-result.md
+++ b/source/core-developers/velocity-result.md
@@ -7,16 +7,69 @@ title: Velocity Result
 
 
 
-{% snippet id=description|javadoc=true|url=org.apache.struts2.dispatcher.VelocityResult %}
+{% comment %}start snippet id=description|javadoc=true|url=org.apache.struts2.result.VelocityResult {% endcomment %}
+<p>
+
+ Using the Servlet container's {@link JspFactory}, this result mocks a JSP
+
+ execution environment and then displays a Velocity template that will be
+
+ streamed directly to the servlet output.
+
+
+</p>
+{% comment %}end snippet id=description|javadoc=true|url=org.apache.struts2.result.VelocityResult {% endcomment %}
 
 ####Parameters####
 
 
 
-{% snippet id=params|javadoc=true|url=org.apache.struts2.dispatcher.VelocityResult %}
+{% comment %}start snippet id=params|javadoc=true|url=org.apache.struts2.result.VelocityResult {% endcomment %}
+<p>
+
+ <ul>
+
+
+
+ <li><b>location (default)</b> - the location of the template to process.</li>
+
+
+
+ <li><b>parse</b> - true by default. If set to false, the location param will
+
+ not be parsed for Ognl expressions.</li>
+
+
+
+ </ul>
+
+ <p>
+
+ This result follows the same rules from {@link StrutsResultSupport}.
+
+ </p>
+
+
+</p>
+{% comment %}end snippet id=params|javadoc=true|url=org.apache.struts2.result.VelocityResult {% endcomment %}
 
 ####Examples####
 
 
 
-{% snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.dispatcher.VelocityResult %}
+{% comment %}start snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.result.VelocityResult {% endcomment %}
+
+
+```xml
+
+ <result name="success" type="velocity">
+
+   <param name="location">foo.vm</param>
+
+ </result>
+
+
+```
+
+
+{% comment %}end snippet id=example|lang=xml|javadoc=true|url=org.apache.struts2.result.VelocityResult {% endcomment %}

--- a/source/tag-developers/ajax-common-header.md
+++ b/source/tag-developers/ajax-common-header.md
@@ -7532,7 +7532,10 @@ __Description__
 
 
 
-{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Div %}
+{% comment %}start snippet id=javadoc|javadoc=true|url=https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/components/Div.java;h=5967686a4283c45d90558a0831e22122df47f35e;hb=974e051bc5e2541261c44cd6fc27717dfcb3267b {% endcomment %}
+<p> Creates an HTML \<div\>
+</p>
+{% comment %}end snippet id=javadoc|javadoc=true|url=https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/components/Div.java;h=5967686a4283c45d90558a0831e22122df47f35e;hb=974e051bc5e2541261c44cd6fc27717dfcb3267b {% endcomment %}
 
 
 

--- a/source/tag-developers/div-tag.md
+++ b/source/tag-developers/div-tag.md
@@ -9,7 +9,10 @@ __Description__
 
 
 
-{% snippet id=javadoc|javadoc=true|url=org.apache.struts2.components.Div %}
+{% comment %}start snippet id=javadoc|javadoc=true|url=https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/components/Div.java;h=5967686a4283c45d90558a0831e22122df47f35e;hb=974e051bc5e2541261c44cd6fc27717dfcb3267b {% endcomment %}
+<p> Creates an HTML \<div\>
+</p>
+{% comment %}end snippet id=javadoc|javadoc=true|url=https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/components/Div.java;h=5967686a4283c45d90558a0831e22122df47f35e;hb=974e051bc5e2541261c44cd6fc27717dfcb3267b {% endcomment %}
 
 
 


### PR DESCRIPTION
Now all snippets resolved except that their url is `/org/apache/struts2/components/DateTextField.java`. I searched history and even googled the whole internet and also reviewed similar resources like DateTextField-tag.html but it seems that `DateTextField.java` never has any snippet!

# Another known issue
For example in [Div.java](https://gitbox.apache.org/repos/asf?p=struts.git;a=blob_plain;f=core/src/main/java/org/apache/struts2/components/Div.java;h=5967686a4283c45d90558a0831e22122df47f35e;hb=974e051bc5e2541261c44cd6fc27717dfcb3267b), as snippet javadoc will included as html (no lang), the `<` and `>` should be escaped twice; maybe we have same issues in our previous replaced snippets. There is no way to determine to escape or not escape html tags except in .java files.