### PR TITLE
Maybe it should be "isOver21"

### DIFF
--- a/source/getting-started/form-tags.md
+++ b/source/getting-started/form-tags.md
@@ -194,7 +194,7 @@ the checkbox will not be checked.
 <s:checkbox key="personBean.over21" />
 ```
 
-Since the method getOver21 returns true, the checkbox is checked.
+Since the method isOver21 returns true, the checkbox is checked.
 
 **HTML Created By Struts 2 Checkbox Tag**
 


### PR DESCRIPTION
Maybe it should be "isOver21"[proof](https://github.com/apache/struts-examples/blob/master/form-tags/src/main/java/org/apache/struts/edit/model/Person.java)
![image](https://user-images.githubusercontent.com/3983683/33265622-592d5c4e-d3ad-11e7-80b2-9c9747969cac.png)

Since the field "over21" is a boolean value, we often use "isOver21" as the "get" method for this field, I suppose. ^_^