### PR TITLE
Use http://code.jquery.com instead of googleapis.com

### DIFF
--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -15,7 +15,7 @@
   <link href="/css/custom.css" rel="stylesheet">
   <link href="/highlighter/github-theme.css" rel="stylesheet">
 
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+  <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
   <script type="text/javascript" src="/bootstrap/js/bootstrap.js"></script>
   <script type="text/javascript" src="/js/community.js"></script>
 </head>


### PR DESCRIPTION
googleapis.com and all google*.com are not available in China

Missing jQuery, I guess, is the reason why top menu does not have submenu

![image](https://user-images.githubusercontent.com/1614482/33541520-71042d18-d90a-11e7-8f7d-e4198d24910a.png)
