### PR TITLE
Mention Maven and maven-archetypes on download page

### DIFF
--- a/source/download.html
+++ b/source/download.html
@@ -11,6 +11,12 @@ title: Download a Release
 </p>
 
 <p>
+  You can start with Apache Struts using <a href="//maven.apache.org">Apache Maven</a> and optionally provided
+  <a href="/maven-archetypes/">archetypes</a> for easier dependency management and version upgrade.
+  Or download some of distributions for fully offline development.
+</p>
+
+<p>
   Use the links below to download a release of Apache Struts from one of our mirrors. You can
   <a href="#verify">verify the integrity</a> of the downloaded files using signatures downloaded from our
   main distribution directory.


### PR DESCRIPTION
Mention Maven and maven-archetypes on download page



btw, Essential Dependencies Only .zip file content is just `struts2-core` dependencies

		<dependency>
			<groupId>org.apache.struts</groupId>
			<artifactId>struts2-core</artifactId>
			<version>${struts2.version}</version>
		</dependency>

Would that xml be good for download page ? (Would be other PR)