### PR TITLE
Link from Releases to Download page

### DIFF
--- a/source/downloads.html
+++ b/source/downloads.html
@@ -12,6 +12,7 @@ title: Releases
 <p>
   Releases of the Apache Struts framework are made available to the general public at no charge,
   under the <a href="https://www.apache.org/licenses/">Apache License,</a> in both binary and source distributions.
+  Full releases for current version are listed at <a href="/download">Download page</a>.
   Individual JARs are also made available through <a href="http://maven.apache.org">Apache Maven</a>
   repositories, like <a href="http://ibiblio.org">ibiblio.</a>
 </p>


### PR DESCRIPTION
> Full releases for current version are listed at <a href="/download">Download page</a>.

ref https://github.com/apache/struts-site/pull/48#issuecomment-349255246