### PR TITLE
rename Home menu item to Releases

### DIFF
--- a/source/_includes/header.html
+++ b/source/_includes/header.html
@@ -24,7 +24,7 @@
               </a>
               <ul class="dropdown-menu">
                 <li><a href="/index.html">Welcome</a></li>
-                <li><a href="/downloads.html">Downloads</a></li>
+                <li><a href="/downloads.html">Releases</a></li>
                 <li><a href="/announce.html">Announcements</a></li>
                 <li><a href="http://www.apache.org/licenses/">License</a></li>
                 <li><a href="https://www.apache.org/foundation/thanks.html">Thanks!</a></li>


### PR DESCRIPTION
Downloads (that are actually all Releases) are easily confused with Download page at `/download`

ref https://github.com/apache/struts-site/pull/48#issuecomment-349255246