### PR TITLE
[important] Update Struts 2.3.x 2017 releases

### DIFF
--- a/source/downloads.html
+++ b/source/downloads.html
@@ -120,6 +120,18 @@ title: Releases
   </tr>
   <tr>
     <td class="no-wrap">
+      Struts 2.3.34
+    </td>
+    <td class="no-wrap">March 2017</td>
+    <td>
+    </td>
+    <td>
+      <a href="/docs/version-notes-2334.html">Version notes</a>
+    </td>
+  </tr>
+  
+  <tr>
+    <td class="no-wrap">
       Struts 2.5.13
     </td>
     <td class="no-wrap">5 September 2017</td>
@@ -170,13 +182,12 @@ title: Releases
     <td class="no-wrap">
       Struts 2.3.32
     </td>
-    <td class="no-wrap">18 Oct 2016</td>
+    <td class="no-wrap">March 2017</td>
     <td>
-      <a href="/docs/s2-048.html">S2-048</a>,
-      <a href="/docs/s2-045.html">S2-045</a>
+      <a href="/docs/s2-048.html">S2-048</a>
     </td>
     <td>
-      <a href="/docs/version-notes-2331.html">Version notes</a>
+      <a href="/docs/version-notes-2332.html">Version notes</a>
     </td>
   </tr>
   <tr>

--- a/source/downloads.html
+++ b/source/downloads.html
@@ -161,6 +161,17 @@ title: Releases
   </tr>
   <tr>
     <td class="no-wrap">
+      Struts 2.3.33
+    </td>
+    <td class="no-wrap">July 2017</td>
+    <td>
+    </td>
+    <td>
+      <a href="/docs/version-notes-2333.html">Version notes</a>
+    </td>
+  </tr>
+  <tr>
+    <td class="no-wrap">
       Struts 2.5.10.1
     </td>
     <td class="no-wrap">7 March 2017</td>

--- a/source/downloads.html
+++ b/source/downloads.html
@@ -122,7 +122,7 @@ title: Releases
     <td class="no-wrap">
       Struts 2.3.34
     </td>
-    <td class="no-wrap">March 2017</td>
+    <td class="no-wrap">September 2017</td>
     <td>
     </td>
     <td>


### PR DESCRIPTION
Acording to http://mvnrepository.com/artifact/org.apache.struts/struts2-core 
2.3.32, 2.3.33, 2.3.34 were released to Maven Central, and as such must be listed on http://struts.apache.org/downloads.html

(The FAQ say only those releases not published may be missing in the list
http://struts.apache.org/kickstart.html#looking-at-the-releases-page-some-versions-seem-to-be-missing-what-happened-to-them
)