### PR TITLE
[not for hurry] add menu link to http://struts.apache.org/maven/ site

### DIFF
--- a/source/_includes/header.html
+++ b/source/_includes/header.html
@@ -65,6 +65,7 @@
                 <li><a href="/tag-developers/">Tag Developers Guide</a></li>
                 <li><a href="/maven-archetypes/">Maven Archetypes</a></li>
                 <li><a href="/plugins/">Plugins</a></li>
+                <li><a href="/maven/">Maven-generated site</a></li>
                 <li><a href="/maven/struts2-core/apidocs/index.html">Struts Core API</a></li>
                 <li><a href="/tag-developers/tag-reference.html">Tag reference</a></li>
                 <li><a href="https://cwiki.apache.org/confluence/display/WW/FAQs">FAQs</a></li>


### PR DESCRIPTION
http://struts.apache.org/maven/ site is generated from main sources, and recently under active updates.

I included JavaDocs for `-core` (and should be other modules as well)