### PR TITLE
#46 Use http://code.jquery.com instead of googleapis.com

### DIFF
--- a/source/_layouts/core-developers.html
+++ b/source/_layouts/core-developers.html
@@ -15,7 +15,7 @@
   <link href="/css/custom.css" rel="stylesheet">
   <link href="/highlighter/github-theme.css" rel="stylesheet">
 
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+  <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
   <script type="text/javascript" src="/bootstrap/js/bootstrap.js"></script>
   <script type="text/javascript" src="/js/community.js"></script>
 </head>


### PR DESCRIPTION
googleapis.com and all google*.com are not available in China,  
and that makes menu non-clickable. #46