### PR TITLE
use {{ site.wiki_url }}/Version+Notes+{{ site.current_version }}.html

### DIFF
--- a/source/download.html
+++ b/source/download.html
@@ -76,7 +76,7 @@ title: Download a Release
 
 <ul>
   <li>
-    <a href="https://struts.apache.org/docs/version-notes-{{ site.current_version_short }}.html">Version Notes</a>
+    <a href="{{ site.wiki_url }}/Version+Notes+{{ site.current_version }}.html">Version Notes</a>
   </li>
 
   <li>Full Distribution:

--- a/source/download.html
+++ b/source/download.html
@@ -76,7 +76,7 @@ title: Download a Release
 
 <ul>
   <li>
-    <a href="{{ site.wiki_url }}/Version+Notes+{{ site.current_version }}.html">Version Notes</a>
+    <a href="{{ site.wiki_url }}/Version+Notes+{{ site.current_version }}">Version Notes</a>
   </li>
 
   <li>Full Distribution:


### PR DESCRIPTION
current https://struts.apache.org/docs/version-notes-2514.1.html fails