### PR TITLE
in menu - Contributing - Source Code and Builds

### DIFF
--- a/source/_includes/header.html
+++ b/source/_includes/header.html
@@ -81,7 +81,7 @@
                 <li><a href="/dev-mail.html">Development Lists</a></li>
                 <li class="divider"></li>
                 <li><a href="/submitting-patches.html">Submitting patches</a></li>
-                <li><a href="/builds.html">Source Code</a></li>
+                <li><a href="/builds.html">Source Code and Builds</a></li>
                 <li><a href="/coding-standards.html">Coding standards</a></li>
                 <li><a href="https://cwiki.apache.org/confluence/display/WW/Contributors+Guide">Contributors Guide</a></li>
                 <li class="divider"></li>


### PR DESCRIPTION
related to #80

---

BTW "Releases" http://struts.apache.org/downloads

>  Trunk Snapshots - Get involved with the latest and greatest fixes and improvements

>    Struts 2 Latest Snapshots from Jenkins CI
>    Maven Snapshots are available from the Apache Maven Repository .

Snapshot builds, and not releases, and should be mention in http://struts.apache.org/builds

Nevertheless the link https://builds.apache.org/view/S-Z/view/Struts/job/Struts-JDK6-develop/lastSuccessfulBuild/org.apache.struts$struts2-assembly/ is brocken.

