### PR TITLE
Remove trailing space so that Bean Validation header is correctly displayed

### DIFF
--- a/source/core-developers/validation.md
+++ b/source/core-developers/validation.md
@@ -27,7 +27,7 @@ for the action.
 ## Using Annotations
 
 [Annotations](validation-annotation.html) can be used as an alternative to XML for validation.
- 
+
 ## Bean Validation
 
 With struts 2.5 comes the Bean Validation Plugin. That is an alternative to the classic struts validation described here. 


### PR DESCRIPTION
With the extra space, looks like the Markdown processor gets confused and instead displays the header as normal paragraph text, as "## Bean Valiation".