### PR TITLE
Re-word date validation paragraph

### DIFF
--- a/source/core-developers/date-validator.md
+++ b/source/core-developers/date-validator.md
@@ -9,7 +9,7 @@ title: date validator
 
 Field Validator that checks if the date supplied is within a specific range.
 
-**NOTE:** If no date converter is specified, `XWorkBasicConverter` will kick in to do the date conversion, which by default using the `Date.SHORT` format using the a problematically specified locale else falling back to the system default locale.
+**NOTE:** If no date converter is specified, `XWorkBasicConverter` will kick in to do the date conversion, which by default using the `Date.SHORT` format using the specified locale else falling back to the system default locale.
 
 ## Parameters
 


### PR DESCRIPTION
I think that part removed was not intentional. Probably kept accidentally when writing/updating the page.