### PR TITLE
Possible site tag documentation updates for WW-5093.

### DIFF
--- a/source/core-developers/accessing-application-session-request-objects.md
+++ b/source/core-developers/accessing-application-session-request-objects.md
@@ -59,7 +59,7 @@ doesn't exist, it will search the request, session, and application scopes, in t
 **Accessing attributes in the Application, Session, Request, or Page scope from a JSP**
 
 ```jsp
-Retrieve the attribute (property), with key myId, from the specified scope:
+<p>Retrieve the attribute (property), with key myId, from the specified scope:</p>
 
 <s:property value="#application.myId" />
 
@@ -69,5 +69,5 @@ Retrieve the attribute (property), with key myId, from the specified scope:
 
 <s:property value="#attr.myId" />
 
-Reminder: attr is for Page scope attributes first, but will search the remaining scopes, in order, seeking a match.
+<p>Reminder: #attr is for Page scope attributes first, but will search the remaining scopes, in order, seeking a match.</p>
 ```

--- a/source/core-developers/accessing-application-session-request-objects.md
+++ b/source/core-developers/accessing-application-session-request-objects.md
@@ -20,16 +20,16 @@ All the JEE scope attribute maps can be accessed via `ActionContext`.
 
 ```java
 Map attr = (Map) ActionContext.getContext().get("attr");
-attr.put("myId",myProp);
+attr.put("myId", myProp);  // Page scope.
 
 Map application = (Map) ActionContext.getContext().get("application");
-application.put("myId",myProp);
+application.put("myId", myProp);
 
 Map session = (Map) ActionContext.getContext().get("session");
 session.put("myId", myProp);
 
 Map request = (Map) ActionContext.getContext().get("request");
-request.put("myId",myProp);
+request.put("myId", myProp);
 ```
 
 > Do not use `ActionContext.getContext()` in the constructor of your Action class. The values may not be set up, and 
@@ -50,16 +50,24 @@ is an alternative way to access the request and response objects, with the same 
 ## Accessing from the view (JSP, FreeMarker, etc.)
 
 Request and session attributes are accessed via OGNL using the `#session` and `#request` stack values.
+Page attributes are accessed via OGNL using the `#attr` stack value, and Application attributes via
+the `#application` stack value.
 
 The `#attr` stack value will search the `javax.servlet.jsp.PageContext` for the specified key. If the `PageContext`
-doean't exist, it will search the request, session, and application scopes, in that order.
+doesn't exist, it will search the request, session, and application scopes, in that order.
 
-**Accessing the Session or Request from a JSP**
+**Accessing attributes in the Application, Session, Request, or Page scope from a JSP**
 
 ```jsp
+Retrieve the attribute (property), with key myId, from the specified scope:
+
+<s:property value="#application.myId" />
+
 <s:property value="#session.myId" />
 
 <s:property value="#request.myId" />
 
 <s:property value="#attr.myId" />
+
+Reminder: attr is for Page scope attributes first, but will search the remaining scopes, in order, seeking a match.
 ```

--- a/source/tag-developers/set-tag.md
+++ b/source/tag-developers/set-tag.md
@@ -25,9 +25,10 @@ The scopes available are as follows:
 - `session` - the value will be set in session scope according to servlet spec. using the name as key
 - `request` - the value will be set in request scope according to servlet spec. using the name as key
 - `page` - the value will be set in page scope according to servlet spec. using the name as key
-- `action` - the value will be set in the request scope and Struts' action context using the name as key
+- `action` - the value will be set in the page scope and Struts' action context using the name as key
 
-> **NOTE**: If no scope is specified, it will default to `action` scope.
+> **NOTE**: If no scope is specified, it will default to `action` scope.  For the `set` tag **specifically**, this also
+> places (sets) the generated value into the `page` scope as well.
 
 {% remote_file_content https://raw.githubusercontent.com/apache/struts/master/core/src/site/resources/tags/set-description.html %}
 

--- a/source/tag-developers/set-tag.md
+++ b/source/tag-developers/set-tag.md
@@ -24,11 +24,11 @@ The scopes available are as follows:
 - `application` - the value will be set in application scope according to servlet spec. using the name as its key
 - `session` - the value will be set in session scope according to servlet spec. using the name as key
 - `request` - the value will be set in request scope according to servlet spec. using the name as key
-- `page` - the value will be set in page scope according to servlet spec. using the name as key
+- `page` - the value will be set in page scope according to servlet spec. using the name as key (retrieve via #attr)
 - `action` - the value will be set in the page scope and Struts' action context using the name as key
 
 > **NOTE**: If no scope is specified, it will default to `action` scope.  For the `set` tag **specifically**, this also
-> places (sets) the generated value into the `page` scope as well.
+> places (sets) the generated value into the `page` scope as well (retrieve via #attr).
 
 {% remote_file_content https://raw.githubusercontent.com/apache/struts/master/core/src/site/resources/tags/set-description.html %}
 

--- a/source/tag-developers/text-tag.md
+++ b/source/tag-developers/text-tag.md
@@ -30,6 +30,9 @@ For more details on using resource bundles with Struts 2 read the [localization 
 
 {% remote_file_content https://raw.githubusercontent.com/apache/struts/master/core/src/site/resources/tags/text-attributes.html %}
 
+> **NOTE**: When the `var` attribute is used with the `text` tag, the tag's generated value **will not** be written out to the
+> visible page (it will only be placed into the action scope).
+
 ## Examples
 
 > Accessing messages from a given bundle (the i18n Shop example bundle in the first example) and using bundle defined 

--- a/source/tag-developers/url-tag.md
+++ b/source/tag-developers/url-tag.md
@@ -54,6 +54,9 @@ See [Constant Configuration](../core-developers/constant-configuration) for furt
 
 {% remote_file_content https://raw.githubusercontent.com/apache/struts/master/core/src/site/resources/tags/url-attributes.html %}
 
+> **NOTE**: When the `var` attribute is used with the `url` tag, the tag's generated URL value will be placed into the request scope
+> **in addition to** the action scope.
+
 ## Examples
 
 ```jsp


### PR DESCRIPTION
Possible site tag documentation updates for WW-5093.
- Minor updates to set, text and url tag text, to clarify scope and behaviour.
- Minor clarifications on "accessing-application-session-request-objects", plus a few other minor edits.