### PR TITLE
Announces Apache Struts 2.5.29 and fixes a few typos

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,15 +9,15 @@ kramdown:
   syntax_highlighter: rouge
 
 # Simplifies introducing changes related to the latest release
-current_version: 2.5.28.3
-current_version_short: 25283
+current_version: 2.5.29
+current_version_short: 2529
 prev_version: 2.3.37
 prev_version_short: 2337
 archetype_version: 2.5.22
 current_beta_version: 2.5-BETA3
 current_beta_version_short: 25B3
-release_date: 02 January 2022
-release_date_short: 20220102
+release_date: 22 January 2022
+release_date_short: 20220122
 prev_release_date: 30 December 2018
 prev_release_date_short: 20181230
 beta_release_date_short: 20160126

--- a/source/_layouts/main-page.html
+++ b/source/_layouts/main-page.html
@@ -16,6 +16,8 @@
   <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
   <script type="text/javascript" src="/bootstrap/js/bootstrap.js"></script>
   <script type="text/javascript" src="/js/community.js"></script>
+
+  <script async defer src="https://buttons.github.io/buttons.js"></script>
 </head>
 <body>
 

--- a/source/announce-2022.md
+++ b/source/announce-2022.md
@@ -13,6 +13,33 @@ title: Announcements 2022
   Skip to: <a href="announce-2021">Announcements - 2021</a>
 </p>
 
+#### 22 January 2022 - Struts 2.5.29 General Availability {#a20220122}
+
+The Apache Struts group is pleased to announce that Struts 2.5.29 is available as a "General Availability"
+release. The GA designation is our highest quality grade.
+
+Bugs:
+ - [WW-5117] - %{id} evaluates different for data-* and value attribute
+ - [WW-5160] - Template not found for name "Empty{name='templateDir'}/simple/hidden.ftl"
+ - [WW-5163] - Error executing FreeMarker template
+
+> Please read the [Version Notes]({{ site.wiki_url }}/Version+Notes+2.5.29) to find more details about performed
+> bug fixes and improvements.
+
+Apache Struts 2 is an elegant, extensible framework for creating enterprise-ready Java web applications.
+The framework has been designed to streamline the full development cycle, from building, to deploying,
+to maintaining applications over time.
+
+**All developers are strongly advised to perform this upgrade.**
+
+The 2.5.x series of the Apache Struts framework has a minimum requirement of the following specification versions:
+Servlet API 2.4, JSP API 2.0, and Java 7.
+
+Should any issues arise with your use of any version of the Struts framework, please post your comments to the user list,
+and, if appropriate, file [a tracking ticket]({{ site.jira_url }}).
+
+You can download this version from our [download](download.cgi#struts-ga) page.
+
 #### 02 January 2022 - Struts 2.5.28.3 General Availability {#a20220102}
 
 The Apache Struts group is pleased to announce that Struts 2.5.28.3 is available as a "General Availability"
@@ -24,7 +51,7 @@ by using the latest Log4j ver. 2.12.4 (Java 1.7 compatible).
 **Please note, that the Apache Struts itself depends on the `log4j-api` package only, it's users' responsibility 
 to use a proper version of the log4j-core package!**
 
-> Please read the [Version Notes]({{ site.wiki_url }}/Version+Notes+2.5.28.2) to find more details about performed
+> Please read the [Version Notes]({{ site.wiki_url }}/Version+Notes+2.5.28.3) to find more details about performed
 > bug fixes and improvements.
 
 Apache Struts 2 is an elegant, extensible framework for creating enterprise-ready Java web applications.

--- a/source/css/main.css
+++ b/source/css/main.css
@@ -6906,7 +6906,7 @@ body > .container.index > section {
   text-align: left;
 }
 
-.contact-channels .channels .twitter-btn, .contact-channels .channels .gplus-btn, .contact-channels .channels .facebook-btn, .contact-channels .channels .irc-btn {
+.contact-channels .channels .twitter-btn, .contact-channels .channels .github-btn, .contact-channels .channels .facebook-btn, .contact-channels .channels .irc-btn {
   padding: .5rem 0;
   vertical-align: middle
 }
@@ -6965,7 +6965,7 @@ footer.container > .col-md-12 {
     text-align: center;
   }
 
-  .contact-channels .channels .twitter-btn, .contact-channels .channels .gplus-btn, .contact-channels .channels .facebook-btn, .contact-channels .channels .irc-btn {
+  .contact-channels .channels .twitter-btn, .contact-channels .channels .github-btn, .contact-channels .channels .facebook-btn, .contact-channels .channels .irc-btn {
     margin-right: 30px;
     display: inline-block
   }

--- a/source/index.html
+++ b/source/index.html
@@ -31,7 +31,7 @@ title: Welcome to the Apache Struts project
         <a href="{{ site.wiki_url }}/Version+Notes+{{ site.current_version }}">Version notes</a>
       </div>
       <div class="column col-md-4">
-        <h2>Security Advice on Log4j 2.12.2/2.16.0</h2>
+        <h2>Security Advice on Log4j 2.12.4/2.17.1</h2>
         <p>
           The Apache Struts Security team would like to announce that all the users using
           the latest Struts 2.5.x series should either upgrade to Apache Struts 2.5.28.3 which

--- a/source/index.html
+++ b/source/index.html
@@ -84,18 +84,15 @@ title: Welcome to the Apache Struts project
   <div class="col-md-12"><h5>Keep in touch: </h5>
 
     <div class="channels">
-      <div class="irc-btn">IRC: <a href="irc://irc.freenode.net/struts">#struts</a></div>
       <div class="facebook-btn">
-        <div data-href="https://www.facebook.com/apachestruts" data-width="250" data-layout="button_count"
-             data-action="like" data-show-faces="false" data-share="true" class="fb-like"></div>
+        <div data-href="https://www.facebook.com/apachestruts" data-width="250" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true" class="fb-like"></div>
       </div>
       <div class="github-btn">
-        <!-- Place this tag where you want the button to render. -->
         <a class="github-button" href="https://github.com/apache/struts" data-color-scheme="no-preference: light; light: light; dark: light;" data-show-count="true" aria-label="Star apache/struts on GitHub">Star</a>
       </div>
-      <div class="twitter-btn"><a href="https://twitter.com/TheApacheStruts" data-show-count="false" data-lang="en"
-                                  data-width="240px" data-align="left" class="twitter-follow-button">Follow
-        @TheApacheStruts</a></div>
+      <div class="twitter-btn">
+        <a href="https://twitter.com/TheApacheStruts" data-show-count="false" data-lang="en" data-width="240px" data-align="left" class="twitter-follow-button">Follow @TheApacheStruts</a>
+      </div>
     </div>
   </div>
 </div>

--- a/source/index.html
+++ b/source/index.html
@@ -34,10 +34,10 @@ title: Welcome to the Apache Struts project
         <h2>Security Advice on Log4j 2.12.2/2.16.0</h2>
         <p>
           The Apache Struts Security team would like to announce that all the users using
-          the latest Struts 2.5.x series should either upgrade to Apache Struts 2.5.28.1 which
-          uses Log4j 2.12.2 version that addresses <a href="https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45046">CVE-2021-45046</a>
-          or upgrade Log4j to version 2.12.2 (when running on Java 1.7) or 2.16.0 (when running on Java 8+).
-          Read more in <a href="announce-2021#a20211212-2">Announcement</a>
+          the latest Struts 2.5.x series should either upgrade to Apache Struts 2.5.28.3 which
+          uses Log4j 2.12.4 version which addresses the latest security vulnerabilities in Log4j
+          or upgrade Log4j to version 2.12.4 (when running on Java 1.7) or 2.17.1 (when running on Java 8+).
+          Read more in <a href="announce-2022#a20220102">Announcement</a>
         </p>
       </div>
       <div class="column col-md-4">

--- a/source/index.html
+++ b/source/index.html
@@ -89,9 +89,9 @@ title: Welcome to the Apache Struts project
         <div data-href="https://www.facebook.com/apachestruts" data-width="250" data-layout="button_count"
              data-action="like" data-show-faces="false" data-share="true" class="fb-like"></div>
       </div>
-      <div class="gplus-btn">
-        <div data-annotation="inline" data-size="medium" data-width="225" data-href="http://struts.apache.org/"
-             class="g-plusone"></div>
+      <div class="github-btn">
+        <!-- Place this tag where you want the button to render. -->
+        <a class="github-button" href="https://github.com/apache/struts" data-color-scheme="no-preference: light; light: light; dark: light;" data-show-count="true" aria-label="Star apache/struts on GitHub">Star</a>
       </div>
       <div class="twitter-btn"><a href="https://twitter.com/TheApacheStruts" data-show-count="false" data-lang="en"
                                   data-width="240px" data-align="left" class="twitter-follow-button">Follow


### PR DESCRIPTION
[Version Notes](https://cwiki.apache.org/confluence/display/WW/Version+Notes+2.5.29)