### PR TITLE
Fix link to v2.5 release notes

### DIFF
--- a/source/.htaccess
+++ b/source/.htaccess
@@ -7,6 +7,7 @@ RewriteCond %{REQUEST_URI} !^/dtds/? [NC]
 RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R,L]
 
 RedirectMatch \/docs\/version\-notes\-25([0-9]{1,2})+\.html   https://cwiki.apache.org/confluence/display/WW/Version+Notes+2.5.$1
+RedirectMatch \/docs\/version\-notes\-25\.html                https://cwiki.apache.org/confluence/display/WW/Version+Notes+2.5
 RedirectMatch \/docs\/version\-notes\-23([0-9]{1,2})+\.html   https://cwiki.apache.org/confluence/display/WW/Version+Notes+2.3.$1
 RedirectMatch \/docs\/version\-notes\-22([0-9]{1,2})+\.html   https://cwiki.apache.org/confluence/display/WW/Version+Notes+2.2.$1
 RedirectMatch \/docs\/version\-notes\-21([0-9]{1,2})+\.html   https://cwiki.apache.org/confluence/display/WW/Version+Notes+2.1.$1


### PR DESCRIPTION
Something is off with the redirect from /docs to Confluence. This is probably not the best way to fix it. I would actually rather create an issue, but this repo doesn't accept issues, so here you go...