### PR TITLE
Reorder Configurations in web.xml

### DIFF
--- a/source/getting-started/how-to-create-a-struts2-web-application.md
+++ b/source/getting-started/how-to-create-a-struts2-web-application.md
@@ -241,10 +241,6 @@ mapping to `web.xml`. Below is how the `web.xml` may look after adding the filte
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
 	<display-name>Basic Struts2</display-name>
-	<welcome-file-list>
-		<welcome-file>index</welcome-file>
-	</welcome-file-list>
-
 	<filter>
 		<filter-name>struts2</filter-name>
 		<filter-class>org.apache.struts2.dispatcher.filter.StrutsPrepareAndExecuteFilter</filter-class>
@@ -255,6 +251,9 @@ mapping to `web.xml`. Below is how the `web.xml` may look after adding the filte
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 
+	<welcome-file-list>
+		<welcome-file>index</welcome-file>
+	</welcome-file-list>
 </web-app>
 ```
 


### PR DESCRIPTION
## Steps to Reproduce
```
       <display-name>Archetype Created Web Application</display-name>
	<welcome-file-list>
		<welcome-file>index</welcome-file>
	</welcome-file-list>
	
	<filter>
		<filter-name>struts2</filter-name>
		<filter-class>org.apache.struts2.dispatcher.filter.StrutsPrepareAndExecuteFilter</filter-class>
	</filter>
	<filter-mapping>
		<filter-name>struts2</filter-name>
		<url-pattern>/*</url-pattern>
	</filter-mapping>
```
This gives us the warning as 👇
<img width="948" alt="Screenshot 2022-08-04 at 9 35 49 PM" src="https://user-images.githubusercontent.com/57325503/182894987-d99cd00f-87bf-4c2d-8d75-36619114eff0.png">

## Proposed Solution
- This happens because order of the configuration is not correct. The _dtd_ expects it be in the order as shown in the error message (icon, display-name, filter, ...., and then welcome-list)
- Minor change in order works
