### PR TITLE
Linkifies FAQ refs from struts tags page

### DIFF
--- a/source/tag-developers/struts-tags.md
+++ b/source/tag-developers/struts-tags.md
@@ -8,35 +8,35 @@ parent:
 
 # Struts Tags
 
-The framework provides a tag library decoupled from the view technology. In this section, we describe each tag in general 
-terms, such as the attributes it supports, what the behaviors are, and so forth. Most tags are supported in all template 
-languages (see [JSP Tags](jsp-tags), [Velocity Tags](velocity-tags), and [FreeMarker Tags](freemarker-tags)), 
-but some are currently only specific to one language. Whenever a tag doesn't have complete support for every language, 
+The framework provides a tag library decoupled from the view technology. In this section, we describe each tag in general
+terms, such as the attributes it supports, what the behaviors are, and so forth. Most tags are supported in all template
+languages (see [JSP Tags](jsp-tags), [Velocity Tags](velocity-tags), and [FreeMarker Tags](freemarker-tags)),
+but some are currently only specific to one language. Whenever a tag doesn't have complete support for every language,
 it is noted on the tag's reference page.
 
-The types of tags can be broken in to two types: generic and UI. Besides function and responsibility, the biggest 
-difference between the two is that the HTML tags support _templates_  and _themes_ . In addition to the general tag 
-reference, we also provide examples for using these generic tags in each of the support languages.
+The types of tags can be broken in to two types: generic and UI. Besides function and responsibility, the biggest
+difference between the two is that the HTML tags support _templates_  and _themes_ . In addition to the general tag
+reference, we also provide examples for using these generic tags in each of the support languages.s
 
 > Be sure to read the [Tag Syntax](tag-syntax) document to learn how tag attribute syntax works.
 
 ## FAQs
 
-+ _Why do the form tags put table tags around controls_ ?
+* [Why do the form tags put table tags around controls?](https://cwiki.apache.org/confluence/display/WW/Why+do+the+form+tags+put+table+tags+around+controls)
 
-+ _How can I put a String literal in a Javascript call, for instance in an onChange attribute_ ?
+* [How can I put a String literal in a Javascript call, for instance in an onChange attribute?](https://cwiki.apache.org/confluence/display/WW/How+can+I+put+a+String+literal+in+a+Javascript+call%2C+for+instance+in+an+onChange+attribute)
 
-+ _Why won't the 'if' tag evaluate a one char string_ ?
+* [Why won't the 'if' tag evaluate a one char string?](https://cwiki.apache.org/confluence/display/WW/Why+won%27t+the+%27if%27+tag+evaluate+a+one+char+string)
 
-+ _Why does FreeMarker complain that there's an error in my user-directive when I used JSP Tag_ ?
+* [Why does FreeMarker complain that there's an error in my user-directive when I used JSP Tag?](https://cwiki.apache.org/confluence/display/WW/Why+does+FreeMarker+complain+that+there%27s+an+error+in+my+user-directive+when+I+used+JSP+Tag)
 
-+ _Can an action tag run another method apart from the default execute method_ ?
+* [Can an action tag run another method apart from the default execute method?](https://cwiki.apache.org/confluence/display/WW/Can+an+action+tag+run+another+method+apart+from+the+default+execute+method)
 
-+ _Why didn't my action tag get executed when I have validation errors_ ?
+* [Why didn't my action tag get executed when I have validation errors?](https://cwiki.apache.org/confluence/display/WW/Why+didn%27t+my+action+tag+get+executed+when+I+have+validation+errors)
 
-+ _Why are request parameters appended to our hyperlinks_ ?
+* [Why are request parameters appended to our hyperlinks?](https://cwiki.apache.org/confluence/display/WW/Why+are+request+parameters+appended+to+our+hyperlinks)
 
 ## Resources
 
-- [Creating a UI Component in Struts 2](http://www.vitarara.org/cms/struts_2_cookbook/creating_a_ui_component) (Mark Menard)
-- [Struts 2 Tags](http://www.roseindia.net/struts/struts2/struts-2-tags.shtml) (Rose India)
+* [Creating a UI Component in Struts 2](http://www.vitarara.org/cms/struts_2_cookbook/creating_a_ui_component) (Mark Menard)
+* [Struts 2 Tags](http://www.roseindia.net/struts/struts2/struts-2-tags.shtml) (Rose India)


### PR DESCRIPTION
**Issue:**

https://stackoverflow.com/questions/73399099/tr-display-none-when-we-use-shidden-tag-of-struts-in-jsp asked a FAQ entry but the FAQ refs on the doc site weren't links so required more manual effort than seemed reasonable.

**Changes:**

* Normalizes UL markup (the `+` caused the links to render incorrectly)
* Links to cwiki FAQ entries for referenced FAQs
* Editor removed trailing whitespace; non-functional change. Sorry.