### PR TITLE
docs: add EOL versions page and cross-link from related pages

### DIFF
--- a/source/_includes/header.html
+++ b/source/_includes/header.html
@@ -42,6 +42,7 @@
                 <li><a href="https://issues.apache.org/jira/browse/WW">Issue Tracker</a></li>
                 <li><a href="/security.html">Reporting Security Issues</a></li>
                 <li><a href="/commercial-support.html">Commercial Support</a></li>
+                <li><a href="/eol-versions.html">End-of-Life Versions</a></li>
                 <li class="divider"></li>
                 <li><a href="https://cwiki.apache.org/confluence/display/WW/Migration+Guide">Version Notes</a></li>
                 <li><a href="https://cwiki.apache.org/confluence/display/WW/Security+Bulletins">Security Bulletins</a></li>

--- a/source/commercial-support.md
+++ b/source/commercial-support.md
@@ -21,7 +21,7 @@ Explore commercial support options for Apache Struts and JavaEE applications thr
 For detailed assistance, kindly reach out to them directly. Help us keep this list current; if you’re aware of other 
 supportive companies, please share details with us.
 
-Last updated: **2024-12-23**
+Last updated: **2026-04-21**
 
 - <a href="https://softwaremill.com/contact/" rel="nofollow" target="_blank">SoftwareMill</a>
     - contact details:
@@ -31,11 +31,11 @@ Last updated: **2024-12-23**
         - [+48 22 188 11 33](tel:+48221881133) (PL)
         - [+44 56 0156 3406](tel:+445601563406) (UK)
     - scope of support: consulting, Java & UI development, audit
-- <a href="https://www.herodevs.com/support/struts-nes" rel="nofollow" target="_blank">HeroDevs</a>
+- <a href="https://www.herodevs.com/support/struts-nes" rel="nofollow" target="_blank">HeroDevs — Never-Ending Support (NES)</a>
     - contact details:
       - email: [hello@herodevs.com](mailto:hello@herodevs.com)
       - phone: [+1 877-586-1965](tel:+18775861965)
-    - scope of support: Extended Long-Term Security Support for Apache Struts, CVE Remediation
+    - scope of support: extended security coverage and CVE remediation for EOL Apache Struts versions
 
 ## How to add a new company
 

--- a/source/download.md
+++ b/source/download.md
@@ -98,6 +98,10 @@ version of Struts in the 6.x series.
 
 If you are looking for other versions than above please check the <a href="https://archive.apache.org/dist/struts/">Apache Archive</a> site.
 
+Versions no longer listed above are End-of-Life (EOL) and receive no further security patches from the Apache Struts Team.
+If your organization requires continued security coverage for an EOL version, see the [End-of-Life versions](eol-versions.html)
+page for available options.
+
 ## Verify the integrity of the files {#verify}
 
 We recommend that you verify the integrity of the downloaded files using the PGP or MD5/SHA256 signatures.

--- a/source/eol-versions.md
+++ b/source/eol-versions.md
@@ -1,0 +1,42 @@
+---
+layout: default
+title: End-of-Life Versions
+---
+
+# End-of-Life Apache Struts Versions
+{:.no_toc}
+
+* Will be replaced with the ToC, excluding a header
+{:toc}
+
+## What End-of-Life means
+
+When a Struts version reaches End-of-Life (EOL), the Apache Struts Team no longer provides
+security patches, bug fixes, or updates for that branch. Users are strongly encouraged to
+migrate to a [currently supported release](download.cgi).
+
+The user mailing list and issue tracker are the **only** support options hosted by the Apache
+Struts project for supported versions. EOL versions receive no support at all from the project.
+
+## EOL versions
+
+| Branch | EOL date | Announcement |
+|--------|----------|--------------|
+| Struts 2.5.x | 30 October 2023 | [Announcement](announce-2023#a20231030) |
+| Struts 2.3.x | 12 September 2019 | [Announcement](announce-2019#a20190912) |
+| Struts 1.x | 5 April 2013 | [Announcement](struts1eol-announcement.html) |
+
+For a full list of individual releases that are no longer recommended due to known security issues,
+see the [Releases](releases.html#prior-releases) page.
+
+## Commercial support for EOL versions
+
+If migration is not immediately feasible, third-party vendors offer extended security support
+for EOL Struts versions. The Apache Software Foundation does not endorse any commercial offering;
+the following is provided for informational purposes only.
+
+{:.alert .alert-info}
+[HeroDevs Never-Ending Support (NES)](https://www.herodevs.com/support/struts-nes){:rel="nofollow" target="_blank"}
+— extended security coverage and CVE remediation for EOL Apache Struts versions.
+
+For a full list of commercial support options, see the [Commercial Support](commercial-support.html) page.

--- a/source/index.html
+++ b/source/index.html
@@ -69,11 +69,12 @@ title: Welcome to the Apache Struts project
         </p>
       </div>
       <div class="column col-md-4">
-        <h2>Apache Struts 2.5.x EOL</h2>
+        <h2>End-of-Life Struts Versions</h2>
         <p>
-          The Apache Struts Team informs about discontinuing support for Struts 2.5.x branch, we recommend migration
-          to the latest version of Struts, read more in
-          <a href="announce-2023#a20231030">Announcement</a>
+          Some Struts versions are no longer supported and receive no further security patches.
+          We recommend migrating to the <a href="download.cgi">latest release</a>.
+          If migration is not immediately feasible, see <a href="eol-versions.html">End-of-Life versions</a>
+          for available options.
         </p>
       </div>
     </div>

--- a/source/index.html
+++ b/source/index.html
@@ -39,13 +39,12 @@ title: Welcome to the Apache Struts project
         <a href="{{ site.wiki_url }}/Version+Notes+{{ site.prev_version }}">Version notes</a>
       </div>
       <div class="column col-md-4">
-        <h2>CVE-2025-64775 File leak in multipart request processing causes disk exhaustion (DoS)</h2>
+        <h2>End-of-Life Struts Versions</h2>
         <p>
-          Upgrade to Apache Struts 6.8.0 or 7.1.1 to mitigate the vulnerability.
-        </p>
-        <p>
-          Read more in the <a href="announce-2025#a20251201">Announcement</a> or in
-          the Security Bulletin <a href="{{ site.wiki_url }}/S2-068">S2-068</a>
+          Some Struts versions are no longer supported and receive no further security patches.
+          We recommend migrating to the <a href="download.cgi">latest release</a>.
+          If migration is not immediately feasible, see <a href="eol-versions.html">End-of-Life versions</a>
+          for available options.
         </p>
       </div>
     </div>
@@ -69,12 +68,13 @@ title: Welcome to the Apache Struts project
         </p>
       </div>
       <div class="column col-md-4">
-        <h2>End-of-Life Struts Versions</h2>
+        <h2>CVE-2025-64775 File leak in multipart request processing causes disk exhaustion (DoS)</h2>
         <p>
-          Some Struts versions are no longer supported and receive no further security patches.
-          We recommend migrating to the <a href="download.cgi">latest release</a>.
-          If migration is not immediately feasible, see <a href="eol-versions.html">End-of-Life versions</a>
-          for available options.
+          Upgrade to Apache Struts 6.8.0 or 7.1.1 to mitigate the vulnerability.
+        </p>
+        <p>
+          Read more in the <a href="announce-2025#a20251201">Announcement</a> or in
+          the Security Bulletin <a href="{{ site.wiki_url }}/S2-068">S2-068</a>
         </p>
       </div>
     </div>

--- a/source/releases.md
+++ b/source/releases.md
@@ -23,6 +23,7 @@ repositories, like [ibiblio.](http://ibiblio.org)
       the [Apache Maven Repository](https://repository.apache.org/content/groups/snapshots/).
 - **Older Releases** are available here
     - [Archive Site](https://archive.apache.org/dist/struts/)
+    - For support options on older releases, see [End-of-Life versions](eol-versions.html)
 
 Project releases have been approved by the vote of the Apache Struts [Project Management Committee.](bylaws.html)
 Support for a release is provided by [project volunteers](volunteers.html)
@@ -37,7 +38,9 @@ The user mailing list and issue tracker are the **only** support options hosted 
 ## Prior Releases {#prior-releases}
 
 As a courtesy, we retain archival copies of the website for releases that initially were considered
-"General Availability" but which has been reclassified as "Not recommended" since they contain security issues
+"General Availability" but which has been reclassified as "Not recommended" since they contain security issues.
+If you are running one of the versions below and cannot migrate, see the [End-of-Life versions](eol-versions.html)
+page for available options.
 
 | Release         | Release Date      | Vulnerability                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Version Notes                                               |
 |-----------------|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|


### PR DESCRIPTION
## Summary

- Adds a new `source/eol-versions.md` page explaining what End-of-Life means, listing EOL Struts branches, and pointing to commercial support options with neutral wording (no ASF endorsement)
- Updates `index.html` — generalizes the 2.5.x-specific EOL card to cover all EOL versions and links to the new page
- Updates `download.md` — adds a note in the Prior Releases section pointing to `eol-versions.html`
- Updates `releases.md` — adds a note before the Prior Releases table and in the Older Releases bullet
- Updates `commercial-support.md` — clarifies the HeroDevs entry description (NES wording) and updates the last-updated date

## Context

Discussed with PMC as part of evaluating a request from HeroDevs to surface commercial EOL support options on the site. The approach taken:
- Keeps vendor promotion off the homepage and download page
- Centralizes EOL support information on a dedicated, purpose-built page
- Uses neutral wording throughout ("ASF does not endorse any commercial offering")
- All existing pages link to the EOL page, not directly to any vendor

Related: https://issues.apache.org/jira/browse/LEGAL-701

## Test plan

- [x] Site builds without errors locally (`./docker-arm64-serve.sh`)
- [x] `eol-versions.html` renders correctly with working links
- [x] Homepage EOL card links to `eol-versions.html`
- [ ] `download.html` Prior Releases note links to `eol-versions.html`
- [x] `releases.html` Prior Releases section and Older Releases bullet link to `eol-versions.html`
- [x] `commercial-support.html` HeroDevs entry reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)