### PR TITLE
docs: replace blocked Marketplace iframes with static card

### DIFF
--- a/source/idea-plugin.md
+++ b/source/idea-plugin.md
@@ -17,13 +17,19 @@ and as well to support the latest IntelliJ IDEA.
 
 Any issues should be reported using ASF JIRA and component [IDEA Plugin](https://issues.apache.org/jira/issues/?jql=project%20%3D%20WW%20AND%20component%20%3D%20%22IDEA%20Plugin%22).
 
-<iframe width="384px" height="319px" src="https://plugins.jetbrains.com/embeddable/card/1698"></iframe>
-
 ## Installation
 
 The plugin is available on the JetBrains Marketplace:
 
-<iframe width="245px" height="48px" src="https://plugins.jetbrains.com/embeddable/install/1698"></iframe>
+<a href="https://plugins.jetbrains.com/plugin/1698-apache-struts"
+   style="display:inline-block;text-decoration:none;color:inherit;border:1px solid #e0e0e0;border-radius:8px;padding:16px;width:340px;font-family:inherit;">
+  <div style="display:flex;align-items:center;gap:12px;">
+    <img src="{{ site.baseurl }}/img/struts-logo.svg" alt="Apache Struts" width="48" height="48" style="flex-shrink:0;"/>
+    <strong style="font-size:1.1em;">Apache Struts</strong>
+  </div>
+  <p style="margin:12px 0 0;color:#555;">Provides full integration of Apache Struts 2.</p>
+  <span style="display:inline-block;margin-top:12px;background:#000;color:#fff;padding:8px 16px;border-radius:20px;font-weight:600;">Get from Marketplace</span>
+</a>
 
 ## Releases
 


### PR DESCRIPTION
## Summary

- The JetBrains Marketplace embeddable widgets (iframe and script-tag versions both load from `plugins.jetbrains.com`) are blocked by the ASF site CSP — `frame-src` and `script-src` only allow `*.apache.org`, ApacheCon, Community Over Code, and `*.scarf.sh`
- Replace the blocked iframes on `source/idea-plugin.md` with a self-contained static card (local Struts logo + name + description + "Get from Marketplace" button-link)
- No external requests, no CSP issues

## Test plan

- [ ] Verify the page renders on staging (https://struts.staged.apache.org/idea-plugin)
- [ ] Confirm the static card displays correctly and the link opens the Marketplace listing