### PR TITLE
WW-5626 docs: clarify @StrutsParameter depth for collections

### DIFF
--- a/source/core-developers/struts-parameter-annotation.md
+++ b/source/core-developers/struts-parameter-annotation.md
@@ -7,6 +7,10 @@ parent:
 ---
 
 # StrutsParameter Annotation
+{:.no_toc}
+
+* Will be replaced with the ToC, excluding a header
+{:toc}
 
 `@StrutsParameter` is a security annotation that marks which fields and methods in your Action class can receive values from user requests.
 
@@ -34,9 +38,38 @@ The placement of the `@StrutsParameter` annotation is crucial and depends on how
     - Checkboxes (single or multiple values).
     - Collections and Maps, when you are populating the whole collection/map from the request.
 
-- **On a public getter method:** Place the annotation on a getter method when you want to allow populating the properties of the object returned by the getter. The `depth` parameter is used to control how deep the object graph can be populated. This is typically used for complex objects or collections of complex objects.
+- **On a public getter method:** Place the annotation on a getter method when you want to allow populating the properties of the object (or objects) returned by the getter. The `depth` parameter controls how deep into that object graph population is allowed — see [Understanding the `depth` parameter](#understanding-the-depth-parameter) below. This is typically used for complex objects or collections of complex objects.
 
 - **On a public field:** For simple types, you can place the annotation directly on the public field as a shorthand for a setter annotation.
+
+## Understanding the `depth` parameter
+
+When you annotate a getter, `depth` limits how far Struts may traverse the object
+graph reachable from that getter while applying request parameters. **Each
+navigation step counts as one level** — following a property *or* indexing into a
+collection or map.
+
+To find the value you need, count the segments after the annotated property in the
+request expression:
+
+| Request expression      | Annotated getter | Steps beyond the getter        | Required `depth` |
+|-------------------------|------------------|--------------------------------|------------------|
+| `user.name`             | `getUser()`      | `.name`                        | `1`              |
+| `user.address.city`     | `getUser()`      | `.address` → `.city`           | `2`              |
+| `users[0].name`         | `getUsers()`     | `[0]` → `.name`                | `2`              |
+
+The key point for collections and maps: **indexing into the collection is itself a
+level.** Reaching a property of a collection element therefore always costs one more
+level than reaching the same property on a plain object. This holds even when the
+element type is a flat POJO with only simple fields — populating `contents[0].title`
+still needs `depth = 2` (one level to reach the element, one more to reach its
+property), not `depth = 1`.
+
+In the annotation's own terms, `depth` is *the number of periods or brackets that
+may appear in the parameter name*. The default is `depth = 0`, which permits only
+setters and fields directly on the action class. Reaching a property of a returned
+object needs `depth = 1` or more; reaching a property of an object held in a
+collection or map needs `depth = 2` or more.
 
 ## Examples
 
@@ -92,21 +125,30 @@ public class MyAction {
 }
 ```
 
-#### Populating properties of objects within a collection
-
-When populating properties of objects that are already in a collection, annotate the getter.
+When populating properties of objects that are already in a collection, annotate the
+getter. Because reaching an element's property requires indexing into the collection
+*and then* following the property, this needs `depth = 2` (see
+[Understanding the `depth` parameter](#understanding-the-depth-parameter)).
 ```java
 public class MyAction {
     private List<User> users; // assume this is initialized in the constructor or elsewhere
 
-    @StrutsParameter(depth = 1)
+    @StrutsParameter(depth = 2)
     public List<User> getUsers() {
         return users;
     }
     // ...
 }
 ```
-This allows requests like `users[0].name=John`.
+This allows requests like `users[0].name=John`. Note that `depth = 2` is required
+even when `User` is a flat object with only simple properties — the extra level pays
+for indexing into the collection, not for nesting within the element.
+
+The same rule applies to JSON and REST payloads: a body such as
+`{"users":[{"name":"John"}]}` populates `users[0].name`, so the `getUsers()` getter
+must be annotated with `depth = 2` for the nested value to be accepted. Annotating
+only the setter is not enough — the JSON/REST authorization checks the getter when
+descending into the collection's elements.
 
 ### Complex object
 


### PR DESCRIPTION
## Summary

Clarifies how the `@StrutsParameter` `depth` parameter is counted and fixes an incorrect example, based on feedback from Markus (flyingfischer.ch) on the user list after the 7.2.1 announcement.

He hit a hard-to-diagnose case adopting the WW-5626 breaking change: populating a `List<MyObject>` property was rejected with `depth = 1` and required `depth = 2`, even though the element was a flat POJO. The docs previously showed `depth = 1` for exactly this collection scenario.

## Changes

- **New section "Understanding the `depth` parameter"** with a worked table, explaining that each property access **or** collection/map index counts as one level — so reaching an element's property costs one more level than the same property on a plain object. Includes the correct default (`depth = 0`) and the canonical rule from the annotation ("number of periods or brackets in the parameter name"), verified against `StrutsParameter.java`.
- **Fixed the collection example** — `getUsers()` now uses `depth = 2` (was `depth = 1`), with a note that this holds even for flat element types.
- **Added a JSON/REST note**: a body like `{"users":[{"name":"John"}]}` populates `users[0].name`, so the getter must be annotated with `depth = 2`; annotating only the setter is not enough.

## Context

- JIRA: [WW-5626](https://issues.apache.org/jira/browse/WW-5626)
- Reported on the `user@struts.apache.org` list in the `[ANN] Apache Struts 7.2.1` thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)