### PR TITLE
ci: provision maven + jdk 17 via tools block in javadocs pipeline

### DIFF
--- a/Jenkinsfile.javadocs
+++ b/Jenkinsfile.javadocs
@@ -14,10 +14,14 @@ pipeline {
     disableConcurrentBuilds()
     skipStagesAfterUnstable()
   }
+  tools {
+    // Provisions `mvn` and JDK 17 on PATH via Jenkins tool installers, matching
+    // the apache/struts build. Struts 7 requires JDK 17.
+    jdk 'jdk_17_latest'
+    maven 'maven_3_latest'
+  }
   environment {
     MAVEN_OPTS = '-Xmx2048m -Dhttps.protocols=TLSv1.2 -DfailOnError=false'
-    // Required: resolves `mvn` on the ASF agent (we use plain mvn, not the wrapper).
-    PATH = "${MAVEN_3_LATEST_HOME}:${env.PATH}"
   }
   stages {
     stage('Build Struts & Maven site') {

--- a/docs/superpowers/plans/2026-07-01-jenkins-javadocs-pipeline.md
+++ b/docs/superpowers/plans/2026-07-01-jenkins-javadocs-pipeline.md
@@ -54,10 +54,14 @@ pipeline {
     disableConcurrentBuilds()
     skipStagesAfterUnstable()
   }
+  tools {
+    // Provisions `mvn` and JDK 17 on PATH via Jenkins tool installers, matching
+    // the apache/struts build. Struts 7 requires JDK 17.
+    jdk 'jdk_17_latest'
+    maven 'maven_3_latest'
+  }
   environment {
     MAVEN_OPTS = '-Xmx2048m -Dhttps.protocols=TLSv1.2 -DfailOnError=false'
-    // Required: resolves `mvn` on the ASF agent (we use plain mvn, not the wrapper).
-    PATH = "${MAVEN_3_LATEST_HOME}:${env.PATH}"
   }
   stages {
     stage('Build Struts & Maven site') {

--- a/docs/superpowers/specs/2026-07-01-jenkins-javadocs-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-01-jenkins-javadocs-pipeline-design.md
@@ -31,9 +31,12 @@ existing website-build pipeline already in this repo.
 
 ## Deliberate changes vs. the current shell script
 
-1. **`./mvnw` → `mvn`.** Use the Maven installation on the ASF agent instead of the
-   Struts project's Maven wrapper. This makes the `MAVEN_3_LATEST_HOME` PATH entry
-   load-bearing (it is what resolves `mvn`), so it is kept.
+1. **`./mvnw` → `mvn`.** Use a Jenkins-provisioned Maven instead of the Struts project's
+   Maven wrapper. Maven and JDK 17 are supplied via a declarative `tools` block
+   (`maven 'maven_3_latest'`, `jdk 'jdk_17_latest'`), matching the apache/struts build.
+   (An earlier draft prepended `MAVEN_3_LATEST_HOME` to `PATH`; that env var is not set on
+   the `git-websites`/`websites2` agent, so `mvn` was not found — the `tools` block is the
+   correct mechanism.)
 2. **`git push origin main` → `git push asf main`.** Mirror the existing `Jenkinsfile`'s
    explicit `asf` remote pattern rather than relying on the ambient `origin`.
 
@@ -68,9 +71,13 @@ options {
   skipStagesAfterUnstable()
 }
 
+tools {
+  jdk 'jdk_17_latest'            // Struts 7 requires JDK 17
+  maven 'maven_3_latest'        // puts `mvn` on PATH on whatever node runs
+}
+
 environment {
   MAVEN_OPTS = '-Xmx2048m -Dhttps.protocols=TLSv1.2 -DfailOnError=false'
-  PATH = "${MAVEN_3_LATEST_HOME}:${env.PATH}"   // required: resolves `mvn` on the ASF agent
 }
 ```
 


### PR DESCRIPTION
Follow-up fix to #309. The first run of the new `Struts-site-javadocs` pipeline failed:

```
+ mvn -B -V clean install -DskipTests
mvn: not found
ERROR: script returned exit code 127
```

## Root cause
`MAVEN_3_LATEST_HOME` is **not set** on the `git-websites`/`websites2` agent, so `PATH = "${MAVEN_3_LATEST_HOME}:${env.PATH}"` prepended an empty entry and `mvn` was never on PATH. The apache/struts Jenkinsfile — on the same ASF Jenkins — provisions tooling with a declarative `tools` block, not env vars.

## Fix
Replace the PATH hack with:

```groovy
tools {
  jdk 'jdk_17_latest'
  maven 'maven_3_latest'
}
```

This puts `mvn` on PATH via the Jenkins tool installer on whatever node runs, and also supplies **JDK 17** (Struts 7 requires it — a latent failure the first run never even reached). The `git-websites` agent and plain `mvn` usage are unchanged.

Spec and plan updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)