### PR TITLE
ci: skip staging site build when a PR changes no site files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,31 @@ pipeline {
     PATH="${GEM_HOME}/bin:${RUBY_PATH}/bin:${env.PATH}"
   }
   stages {
+    stage('Check for site changes') {
+      steps {
+        script {
+          if (env.CHANGE_TARGET) {
+            // PR build: only rebuild when files that affect the generated site changed.
+            sh "git fetch --no-tags origin +refs/heads/${env.CHANGE_TARGET}:refs/remotes/origin/${env.CHANGE_TARGET}"
+            def files = sh(
+                script: "git diff --name-only origin/${env.CHANGE_TARGET}...HEAD",
+                returnStdout: true).trim()
+            echo "Files changed in this PR:\n${files}"
+            env.SITE_CHANGED = files.readLines().any {
+              it ==~ /^(source\/.*|_config\.yml|Gemfile(\.lock)?)$/
+            } ? 'true' : 'false'
+          } else {
+            // Branch build (e.g. main): always rebuild.
+            env.SITE_CHANGED = 'true'
+          }
+          echo "SITE_CHANGED=${env.SITE_CHANGED}"
+        }
+      }
+    }
     stage('Build a staged website') {
+      when {
+        expression { env.SITE_CHANGED == 'true' }
+      }
       steps {
         sh '''
           echo Generating a new version of website
@@ -29,6 +53,9 @@ pipeline {
       }
     }
     stage('Deploy to stage area') {
+      when {
+        expression { env.SITE_CHANGED == 'true' }
+      }
       steps {
         sh '''
           echo "Pushing changes into stage site"
@@ -55,7 +82,10 @@ pipeline {
     }
     stage('Comment on PR') {
       when {
-        changeRequest()
+        allOf {
+          changeRequest()
+          expression { env.SITE_CHANGED == 'true' }
+        }
       }
       steps {
         script {


### PR DESCRIPTION
The `Struts-site` multibranch job rebuilds Jekyll and pushes to `asf-staging` on **every** PR — including PRs that only touch CI or `docs/` and leave `source/` untouched. The staged output is then byte-identical, so the whole build + deploy + PR comment is wasted.

## Fix
Add a lightweight **Check for site changes** stage that diffs the PR against its target branch and sets `SITE_CHANGED`, then gate the existing stages on it:

```groovy
stage('Check for site changes') {
  steps {
    script {
      if (env.CHANGE_TARGET) {
        sh "git fetch --no-tags origin +refs/heads/${env.CHANGE_TARGET}:refs/remotes/origin/${env.CHANGE_TARGET}"
        def files = sh(script: "git diff --name-only origin/${env.CHANGE_TARGET}...HEAD", returnStdout: true).trim()
        env.SITE_CHANGED = files.readLines().any {
          it ==~ /^(source\/.*|_config\.yml|Gemfile(\.lock)?)$/
        } ? 'true' : 'false'
      } else {
        env.SITE_CHANGED = 'true'   // branch build (main): always rebuild
      }
    }
  }
}
```

- **Build** and **Deploy to stage area** run only when `SITE_CHANGED == 'true'`.
- **Comment on PR** runs only on a change request *and* when the site changed.
- Site-affecting paths: anything under `source/`, plus `_config.yml` and `Gemfile`/`Gemfile.lock`.

## Why in-pipeline (not a job-level path filter)
A skipped stage still reports **success**, so if the `Struts-site` build is ever a required PR check, it stays green. A job-level 'included regions' filter would instead prevent the build from starting, so a required check would never report and could block merge.

## Self-test
This PR touches only `Jenkinsfile`, so its own multibranch run should show **Build a staged website** and **Deploy to stage area** as *skipped* — that's the expected, correct outcome here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)