### PR TITLE
ci: skip OWASP dependency-check report in javadocs site build

### DIFF
--- a/Jenkinsfile.javadocs
+++ b/Jenkinsfile.javadocs
@@ -40,7 +40,10 @@ pipeline {
           fi
 
           mvn -B -V clean install -DskipTests
-          mvn -B -V site:site site:stage
+          # Skip the OWASP dependency-check report: its aggregate goal downloads the
+          # full NVD CVE database (~360k records) with no API key, blowing the timeout.
+          # Not needed for the published Maven site.
+          mvn -B -V site:site site:stage -Ddependency-check.skip=true
         '''
       }
     }

--- a/docs/superpowers/plans/2026-07-01-jenkins-javadocs-pipeline.md
+++ b/docs/superpowers/plans/2026-07-01-jenkins-javadocs-pipeline.md
@@ -80,7 +80,9 @@ pipeline {
           fi
 
           mvn -B -V clean install -DskipTests
-          mvn -B -V site:site site:stage
+          # Skip the OWASP dependency-check report: its aggregate goal downloads the
+          # full NVD CVE database (~360k records) with no API key, blowing the timeout.
+          mvn -B -V site:site site:stage -Ddependency-check.skip=true
         '''
       }
     }

--- a/docs/superpowers/specs/2026-07-01-jenkins-javadocs-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-01-jenkins-javadocs-pipeline-design.md
@@ -92,7 +92,9 @@ pollutes the site repo:
 - clone `https://gitbox.apache.org/repos/asf/struts.git` into `target/struts`
 - checkout: if `STRUTS_TAG == main` → `git checkout main`, else `git checkout "tags/${STRUTS_TAG}"`
 - `mvn -B -V clean install -DskipTests`
-- `mvn -B -V site:site site:stage`
+- `mvn -B -V site:site site:stage -Ddependency-check.skip=true` (the OWASP
+  dependency-check report is skipped: its aggregate goal downloads the full NVD CVE
+  database with no API key and blows the build timeout; it is not needed for the site)
 
 **Stage 2 — Publish to source/maven**
 


### PR DESCRIPTION
Follow-up to #309/#310. The javadocs pipeline run **timed out and aborted** during `site:site`:

```
[INFO] Generating "Dependency Check" report --- dependency-check-maven:12.2.2:aggregate
[WARNING] An NVD API Key was not provided ... the update can take a VERY long time
[INFO] NVD API has 362,472 records in this update
[INFO] Downloaded 60,000/362,488 (17%)
Cancelling nested steps due to timeout
Finished: ABORTED
```

## Root cause
The struts pom binds `org.owasp:dependency-check-maven` as a `<reporting>` plugin, so `site:site` runs its `aggregate` goal, which downloads the **entire NVD CVE database (~360k records)**. Without an NVD API key this is throttled/retried and never finished inside the 90-minute timeout.

## Fix
Skip that one report during site generation:

```
mvn -B -V site:site site:stage -Ddependency-check.skip=true
```

`dependency-check.skip` is the plugin's documented user property for the aggregate mojo. The published Maven site doesn't need a security-scan report, so dropping it is the right call — no NVD API key or struts-pom change required. All other site reports (javadoc, project-info, RAT, versions) still generate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)