### PR TITLE
ci: check out asf/main explicitly in javadocs publish stage

### DIFF
--- a/Jenkinsfile.javadocs
+++ b/Jenkinsfile.javadocs
@@ -57,8 +57,9 @@ pipeline {
           fi
 
           git fetch asf
-          git checkout main
-          git pull asf main
+          # Check out asf/main explicitly: the Pipeline SCM checkout also leaves an
+          # origin/main, so a bare `git checkout main` is ambiguous across two remotes.
+          git checkout -B main asf/main
 
           rm -rf source/maven
           mkdir -p source/maven

--- a/docs/superpowers/plans/2026-07-01-jenkins-javadocs-pipeline.md
+++ b/docs/superpowers/plans/2026-07-01-jenkins-javadocs-pipeline.md
@@ -96,8 +96,9 @@ pipeline {
           fi
 
           git fetch asf
-          git checkout main
-          git pull asf main
+          # Check out asf/main explicitly: the Pipeline SCM checkout also leaves an
+          # origin/main, so a bare `git checkout main` is ambiguous across two remotes.
+          git checkout -B main asf/main
 
           rm -rf source/maven
           mkdir -p source/maven

--- a/docs/superpowers/specs/2026-07-01-jenkins-javadocs-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-01-jenkins-javadocs-pipeline-design.md
@@ -101,7 +101,8 @@ pollutes the site repo:
 Mirror the existing `Jenkinsfile` deploy pattern:
 
 - add the `asf` remote if missing → `https://gitbox.apache.org/repos/asf/struts-site.git`
-- `git checkout main` && `git pull asf main`
+- `git checkout -B main asf/main` (explicit remote: a bare `git checkout main` is
+  ambiguous because the Pipeline SCM checkout also leaves an `origin/main`)
 - `rm -rf source/maven && mkdir -p source/maven`
 - `mv target/struts/target/staging/* source/maven/`
 - `git add source/maven`


### PR DESCRIPTION
Follow-up to #309/#310/#312. The build now reaches the publish stage but fails there:

```
+ git fetch asf
 * [new branch]  main -> asf/main
+ git checkout main
fatal: 'main' matched multiple (2) remote tracking branches
```

## Root cause
The Pipeline-from-SCM checkout populates `origin/*` (including `origin/main`). The publish stage then adds an `asf` remote pointing at the same gitbox repo, giving `asf/main` too. With no local `main` branch, `git checkout main` is a DWIM guess across remotes — and since it matches both `origin/main` and `asf/main`, git refuses.

(The legacy site `Jenkinsfile` avoids this because its multibranch checkout only fetches the single PR branch, so no `origin/asf-staging` exists to collide with `asf/asf-staging`.)

## Fix
Pin the intended remote explicitly:

```
git checkout -B main asf/main
```

This creates/points local `main` at `asf/main` unambiguously, and makes the subsequent `git pull asf main` redundant (dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)