### PR TITLE
ci: publish only the menu-linked Maven site modules, flattened

### DIFF
--- a/Jenkinsfile.javadocs
+++ b/Jenkinsfile.javadocs
@@ -61,9 +61,28 @@ pipeline {
           # origin/main, so a bare `git checkout main` is ambiguous across two remotes.
           git checkout -B main asf/main
 
+          # The struts reactor stages module sites nested by POM inheritance, e.g.
+          # struts2-bom/struts2-parent/struts2-core/. Publish only what the website
+          # menu links to: the top-level aggregate site at the root, plus struts2-core
+          # and struts2-plugins flattened to /maven/<module>/. Each module site is
+          # self-contained (own css/js/images) and struts2-plugins carries its own
+          # submodule sites, so moving whole directories keeps their links intact.
+          STAGING=target/struts/target/staging
+          PARENT="${STAGING}/struts2-bom/struts2-parent"
+
           rm -rf source/maven
           mkdir -p source/maven
-          mv target/struts/target/staging/* source/maven/
+
+          # Top-level aggregate site (index.html, project-info.html, aggregate apidocs,
+          # dependency reports), skipping the deeply-nested reactor tree.
+          for entry in "${STAGING}"/*; do
+            [ "$(basename "${entry}")" = "struts2-bom" ] && continue
+            cp -r "${entry}" source/maven/
+          done
+
+          # Flatten the two module sites the website menu references.
+          cp -r "${PARENT}/struts2-core" source/maven/struts2-core
+          cp -r "${PARENT}/struts2-plugins" source/maven/struts2-plugins
 
           git add source/maven
           git status

--- a/docs/superpowers/plans/2026-07-01-jenkins-javadocs-pipeline.md
+++ b/docs/superpowers/plans/2026-07-01-jenkins-javadocs-pipeline.md
@@ -100,9 +100,25 @@ pipeline {
           # origin/main, so a bare `git checkout main` is ambiguous across two remotes.
           git checkout -B main asf/main
 
+          # The struts reactor stages module sites nested by POM inheritance, e.g.
+          # struts2-bom/struts2-parent/struts2-core/. Publish only what the website
+          # menu links to: the top-level aggregate site at the root, plus struts2-core
+          # and struts2-plugins flattened to /maven/<module>/. Each module site is
+          # self-contained (own css/js/images) and struts2-plugins carries its own
+          # submodule sites, so moving whole directories keeps their links intact.
+          STAGING=target/struts/target/staging
+          PARENT="${STAGING}/struts2-bom/struts2-parent"
+
           rm -rf source/maven
           mkdir -p source/maven
-          mv target/struts/target/staging/* source/maven/
+
+          for entry in "${STAGING}"/*; do
+            [ "$(basename "${entry}")" = "struts2-bom" ] && continue
+            cp -r "${entry}" source/maven/
+          done
+
+          cp -r "${PARENT}/struts2-core" source/maven/struts2-core
+          cp -r "${PARENT}/struts2-plugins" source/maven/struts2-plugins
 
           git add source/maven
           git status

--- a/docs/superpowers/specs/2026-07-01-jenkins-javadocs-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-01-jenkins-javadocs-pipeline-design.md
@@ -104,7 +104,17 @@ Mirror the existing `Jenkinsfile` deploy pattern:
 - `git checkout -B main asf/main` (explicit remote: a bare `git checkout main` is
   ambiguous because the Pipeline SCM checkout also leaves an `origin/main`)
 - `rm -rf source/maven && mkdir -p source/maven`
-- `mv target/struts/target/staging/* source/maven/`
+- Publish selectively (the struts reactor nests module sites by POM inheritance, e.g.
+  `struts2-bom/struts2-parent/struts2-core/`, which does not match the website menu):
+  - copy the top-level aggregate site (everything at the staging root **except** the
+    nested `struts2-bom` tree) → `source/maven/` — gives `/maven/project-info.html`,
+    `/maven/index.html`, aggregate `/maven/apidocs/`
+  - copy `…/struts2-bom/struts2-parent/struts2-core` → `source/maven/struts2-core`
+  - copy `…/struts2-bom/struts2-parent/struts2-plugins` → `source/maven/struts2-plugins`
+  - This flattening makes all four `/maven/…` menu links in `source/_includes/header.html`
+    resolve with no menu change. Safe because each module site is self-contained
+    (own css/js/images) and `struts2-plugins` carries its submodule sites. Trade-off:
+    secondary "up"/breadcrumb links inside the Maven pages may not resolve.
 - `git add source/maven`
 - `git diff --cached --quiet || git commit -m "Updates Maven site by Jenkins"`
 - `git push asf main`


### PR DESCRIPTION
Follow-up to the javadocs pipeline. The last (green) run published the full staged reactor, so module sites landed nested by POM inheritance:

```
source/maven/struts2-bom/struts2-parent/struts2-core/dependencies.html
source/maven/struts2-bom/struts2-parent/struts2-plugins/modules.html
```

…but the website menu (`source/_includes/header.html`) links to the flat, pre-Struts-7 layout:

| Menu link | Was it resolving? |
|---|---|
| `/maven/project-info.html` | ✅ (top-level site) |
| `/maven/struts2-core/dependencies.html` | ❌ nested |
| `/maven/struts2-plugins/modules.html` | ❌ nested |
| `/maven/struts2-core/apidocs/index.html` | ❌ nested |

## Fix
Publish only what the menu references, and flatten it:
- top-level aggregate site (staging root **except** the nested `struts2-bom` tree) → `source/maven/`
- `…/struts2-bom/struts2-parent/struts2-core` → `source/maven/struts2-core`
- `…/struts2-bom/struts2-parent/struts2-plugins` → `source/maven/struts2-plugins`

All four menu links now resolve **with no menu change**. This is safe because each module site is self-contained (own `css/js/images`) and `struts2-plugins` carries its own submodule sites, so moving whole directories keeps their internal links intact. It also drops the unreferenced modules (`jakarta`, `apps`, `assembly`) and the `bom`/`parent` scaffolding.

**Trade-off:** secondary "up"/breadcrumb links *inside* the Maven-generated pages (e.g. "Parent Project") assumed the deep nesting and may not resolve after flattening — the report content, apidocs, and all menu targets do.

Verify with a re-run at `STRUTS_TAG=STRUTS_7_2_1` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)