### PR TITLE
docs: JSON input parameter filtering & scalar-collection authorization (Struts 7.3.0)

### DIFF
--- a/source/core-developers/struts-parameter-annotation.md
+++ b/source/core-developers/struts-parameter-annotation.md
@@ -125,6 +125,27 @@ public class MyAction {
 }
 ```
 
+This covers the case where the whole collection is assigned at once (name
+`mySelection`, `depth = 0`), as a checkbox list submits it.
+
+When the collection is instead populated **element by element** through indexed
+names — `mySelection[0]`, `mySelection[1]` — the annotation must be on the
+**getter** with `depth = 1`, because each element path contains one bracket. This
+is how JSON and REST payloads bind a collection of simple types: a body such as
+`{"mySelection":["A","B"]}` populates `mySelection[0]` and `mySelection[1]`, so
+the getter must be annotated for the elements to be accepted.
+```java
+public class MyAction {
+    private List<String> mySelection;
+
+    @StrutsParameter(depth = 1)
+    public List<String> getMySelection() {
+        return mySelection;
+    }
+    // ... setter
+}
+```
+
 When populating properties of objects that are already in a collection, annotate the
 getter. Because reaching an element's property requires indexing into the collection
 *and then* following the property, this needs `depth = 2` (see

--- a/source/plugins/json/index.md
+++ b/source/plugins/json/index.md
@@ -590,6 +590,48 @@ annotation **per property, during deserialization** — unauthorized fields are
 never set on the target object. Annotate the action properties that may be
 populated from the JSON request body.
 
+### Input parameter filtering
+
+Since Struts 7.3.0, populating an action from a JSON request body applies the
+same name/value acceptability controls that the
+[Parameters Interceptor](../../core-developers/parameters-interceptor.html)
+applies to ordinary HTTP request parameters. Filtering uses the same
+dotted/indexed key paths as form parameters (`address.city`, `items[0].name`),
+so the shared pattern checkers behave identically on JSON and form input.
+Population itself stays pure reflection over bean setters — no OGNL name
+evaluation is introduced on the JSON path.
+
+The following controls are **always on**:
+
+- **Excluded and accepted name patterns** — the same framework-wide
+  accepted/excluded parameter-name patterns the Parameters Interceptor uses. A
+  JSON key whose full dotted/indexed path matches an excluded pattern, or fails
+  to match any accepted pattern, is not populated.
+- **Maximum key-path length** — set with the `paramNameMaxLength` interceptor
+  param (default `100`). JSON keys whose full dotted path is longer are rejected.
+- **`ParameterNameAware` / `ParameterValueAware`** action callbacks — honored for
+  JSON input exactly as for form parameters.
+- **`@StrutsParameter` authorization** — see
+  [Parameter authorization](#parameter-authorization) above.
+
+The following controls are **opt-in** — disabled by default to preserve existing
+behavior for permissive JSON apps:
+
+| Interceptor param | Default | Effect |
+|-------------------|---------|--------|
+| `acceptedValuePatterns` | *(none)* | Comma-delimited regular expressions; when set, only JSON leaf **values** matching one of them are accepted (matching is case-insensitive). |
+| `excludedValuePatterns` | *(none)* | Comma-delimited regular expressions; JSON leaf **values** matching any of them are removed (matching is case-insensitive). |
+| `applyPropertyFiltersToInput` | `false` | When `true`, the interceptor's own `excludeProperties` / `includeProperties` patterns — otherwise used only for serialization output — also gate which JSON keys are populated on **input**. |
+
+```xml
+<interceptor-ref name="json">
+  <param name="paramNameMaxLength">120</param>
+  <param name="acceptedValuePatterns">[\w\s.@-]+</param>
+  <param name="applyPropertyFiltersToInput">true</param>
+  <param name="excludeProperties">login.password</param>
+</interceptor-ref>
+```
+
 ## JSON RPC
 
 The json plugin can be used to execute action methods from javascript and return the output. This feature was developed 


### PR DESCRIPTION
### Depends on https://github.com/apache/struts/pull/1784

Documents the JSON parameter-filtering work targeting Struts 7.3.0. Content audit of the following framework PRs:

- apache/struts#1773 (WW-4858, **merged**) — JSON population now honors Parameters Interceptor-style name/value filtering.
- apache/struts#1784 (WW-4858, **open**) — aligns `@StrutsParameter` authorization on the JSON path with `ParametersInterceptor`, including for scalar collection elements.
- apache/struts#1775 (WW-5643) and apache/struts#1776 (WW-5644) — internal reader/writer thread-safety fixes, **no doc surface** (no config change), so not documented here.

Note: `@StrutsParameter` authorization on the JSON path was introduced in **7.2.0** (WW-5624); these PRs adjust the logic to match `ParametersInterceptor`, they do not introduce the authorization.

## Changes

**`source/plugins/json/index.md`** — new *Input parameter filtering* subsection:
- Always-on: framework-wide accepted/excluded name patterns, `paramNameMaxLength` (default `100`), `ParameterNameAware`/`ParameterValueAware`, `@StrutsParameter`.
- Opt-in: `acceptedValuePatterns`, `excludedValuePatterns`, `applyPropertyFiltersToInput`.

**`source/core-developers/struts-parameter-annotation.md`** — extend the collections example to clarify that populating a collection of simple types *element by element* (`mySelection[0]`), as JSON/REST payloads do, requires `@StrutsParameter(depth = 1)` on the **getter** (not the setter).

All config names/defaults verified against merged `main`.

## Notes

- `#1784` is still open; if its scope changes before merge, the collections clarification may need a follow-up.
- Local `jekyll build` could not run (broken system Ruby bundler); relying on the staging auto-build. Internal link targets verified to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)