### PR TITLE
fix: point /announce.html at the newest announce-YYYY page

### DIFF
--- a/.claude/skills/announcing-struts-release/SKILL.md
+++ b/.claude/skills/announcing-struts-release/SKILL.md
@@ -42,8 +42,9 @@ Model PRs: #292 (6.9.0 GA), this skill was derived from the 6.10.0 release.
    line and compare its `announce-YYYY` to the year of your new entry.** If they differ
    (the announcement crossed into a new year file), update the `announce-YYYY` part to the
    new year — the anchor itself is variable-driven. If they already match, no edit.
-   Note: a brand-new year file is the "New announcement year" task in CLAUDE.md — also
-   create `source/announce-YYYY.md` and update the `.htaccess` redirect.
+   Note: a brand-new year file is the "New announcement year" task in CLAUDE.md — just
+   create `source/announce-YYYY.md`; the `.htaccess` `/announce.html` redirect picks up
+   the newest year automatically.
 4. **`source/releases.md`** — move the now-superseded version of the **same line** into
    the **Prior Releases** table, newest first. Match the column widths and the
    vulnerability-cell style of the row above it (empty if no published bulletin).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ bundle exec jekyll serve -w --trace --host 0.0.0.0
   - `_layouts/` - Page templates: `default`, `main-page`, `core-developers`, `maven-archetypes`
   - `_includes/` - Shared partials: `header.html`, `footer.html`
   - `_plugins/` - Custom Liquid tags (see below)
-  - `.htaccess` - Apache redirect rules (update when adding yearly announcement pages)
+  - `.htaccess` - Apache redirect rules (Liquid-processed, has empty front matter)
 - `_config.yml` - Jekyll config and site-wide version/release variables
 - `.asf.yaml` - ASF infrastructure config (deployment, notifications, branch protection)
 
@@ -87,6 +87,6 @@ Kramdown attribute syntax for Bootstrap classes:
 
 **New release**: Update version variables in `_config.yml`, add announcement entry to the current year's `announce-YYYY.md`, and move the now-superseded version into the **Prior Releases** table in `source/releases.md`.
 
-**New announcement year**: Create `source/announce-YYYY.md`, update the redirect in `source/.htaccess` (`RedirectMatch \/announce.html` line) to point to the new year.
+**New announcement year**: Create `source/announce-YYYY.md`. The `/announce.html` redirect in `source/.htaccess` resolves to the newest `announce-YYYY` page at build time, so it needs no manual update.
 
 **New security bulletin**: Add to `source/security/` directory.

--- a/source/.htaccess
+++ b/source/.htaccess
@@ -1,3 +1,6 @@
+---
+# Empty front matter, required so Jekyll renders the Liquid tags below
+---
 # This file is maintained at https://gitbox.apache.org/repos/asf?p=struts-site.git
 DirectoryIndex index.html
 
@@ -25,6 +28,8 @@ RedirectMatch \/2.*\/(.*)?                          http://struts.apache.org/$1
 # page downloads.html was renamed to releases.html
 RedirectMatch \/downloads /releases
 
-RedirectMatch \/announce.html(#a[0-9]+)? /announce-2024.html$1
+# always points to the most recent announce-YYYY page, no manual update needed
+{% assign announcements = site.pages | where_exp: "page", "page.path contains 'announce-'" | sort: "path" -%}
+RedirectMatch \/announce.html(#a[0-9]+)? {{ announcements.last.url }}$1
 
 ErrorDocument 404 /404


### PR DESCRIPTION
## Problem

`source/.htaccess` hardcoded the legacy `/announce.html` redirect to `/announce-2024.html`, so visitors landed on the 2024 announcements even though `announce-2025.md` and `announce-2026.md` exist. The line has to be bumped by hand every January and was missed twice.

## Fix

`.htaccess` now carries empty front matter so Jekyll renders Liquid in it, and the redirect target is resolved from the newest `announce-*` page at build time:

```
{% assign announcements = site.pages | where_exp: "page", "page.path contains 'announce-'" | sort: "path" -%}
RedirectMatch \/announce.html(#a[0-9]+)? {{ announcements.last.url }}$1
```

Adding `source/announce-YYYY.md` for a new year is now enough — the redirect follows automatically. `CLAUDE.md` and the `announcing-struts-release` skill were updated to drop the manual step.

## Verification

Built with Jekyll 4.2 in a scratch site seeded with all 25 real `announce-*` filenames (2002 `.html` … 2026 `.md`). Rendered output:

```
# always points to the most recent announce-YYYY page, no manual update needed
RedirectMatch \/announce.html(#a[0-9]+)? /announce-2026.html$1
```

The rest of the file is byte-identical to before.

Note: old bookmarks of the form `/announce.html#a1234` still carry their anchor through and won't resolve on the year page — those anchors only ever existed on the retired single-page announcements. That was already the case before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)