### PR TITLE
docs: add the one-time release setup steps to the guidelines

### DIFF
--- a/source/release-guidelines.md
+++ b/source/release-guidelines.md
@@ -87,6 +87,65 @@ pom on `main` still read `7.2.2-SNAPSHOT` after 7.3.0 had shipped.
 - ASF credentials for `dist.apache.org` (Subversion) and for
   [Nexus](https://repository.apache.org/).
 
+### Setting up for your first release
+
+These steps are done once, not per release.
+
+#### Publish your code signing key
+
+Releases are signed with your personal OpenPGP key, and that key has to be discoverable by anyone
+verifying the artifacts. Generate one if you do not have it already, publish it to a keyserver,
+then append it to the project's `KEYS` file:
+
+```bash
+svn co --depth files https://dist.apache.org/repos/dist/release/struts/ struts-release
+cd struts-release
+(gpg --fingerprint --list-sigs "Your Name" && gpg --armor --export "Your Name") >> KEYS
+svn commit KEYS -m "Add public key for <your apache id>"
+```
+
+See the ASF guide to [release signing](https://infra.apache.org/release-signing.html) for key
+size, expiry and web-of-trust recommendations.
+
+#### Configure Maven
+
+`release:perform` deploys to Nexus and signs the artifacts, so `~/.m2/settings.xml` needs both
+your ASF credentials and a way to reach your signing key:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>apache.releases.https</id>
+      <username><!-- your ASF LDAP username --></username>
+      <password><!-- your ASF LDAP password --></password>
+    </server>
+    <server>
+      <id>apache.snapshots.https</id>
+      <username><!-- your ASF LDAP username --></username>
+      <password><!-- your ASF LDAP password --></password>
+    </server>
+  </servers>
+</settings>
+```
+
+{:.alert .alert-warning}
+Do not store either password in clear text. Encrypt them with
+[`mvn --encrypt-password`](https://maven.apache.org/guides/mini/guide-encryption.html), and let
+`gpg-agent` hold your signing passphrase rather than putting a `gpg.passphrase` property in
+`settings.xml`.
+
+See [publishing Maven artifacts](https://infra.apache.org/publishing-maven-artifacts.html) for
+the current ASF settings.
+
+#### Give Maven enough memory
+
+A full build with all tests can need more heap than the default:
+
+```bash
+export MAVEN_OPTS=-Xmx1024m
+```
+
 ## The seven phases
 
 A release is seven phases with a gate between each. A phase is finished when its gate is


### PR DESCRIPTION
Follow-up to #324, and a prerequisite for retiring the cwiki release pages.

### Why

#324 left the guidelines saying *what* a release manager needs access to — a signing key, ASF credentials for svn and Nexus — without saying how any of it is configured. That left the cwiki page [One time steps](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27832952) as the only place describing the `KEYS` file and `~/.m2/settings.xml`, and `release:perform` does not work without them. Stubbing that page before porting this would have deleted a working instruction and put nothing in its place.

### What's ported

A `Setting up for your first release` section under *Before you start*, covering the signing key and `KEYS`, the Maven settings, and `MAVEN_OPTS`.

Modernised rather than copied:

- **`KEYS` moved.** It lives in `dist/release/struts` now; the old page appends to a copy in `svn.apache.org/repos/asf/struts/maven/trunk/build` and `scp`s it to `people.apache.org`.
- **The SSH section is dropped entirely.** It existed for `scp` deploys to `people.apache.org` and for a `known_hosts` hashing bug in Maven Wagon — a dead host and a dead code path.
- **Credential handling deviates deliberately.** The old page puts the ASF LDAP password *and* the GPG passphrase in clear text in `settings.xml`. This points at [`mvn --encrypt-password`](https://maven.apache.org/guides/mini/guide-encryption.html) and `gpg-agent` instead, with a warning callout. Publishing the clear-text version on the project website was not something worth doing.
- Links go to `infra.apache.org` rather than the retired `apache.org/dev/` paths.

The retagging and `svn propset` notes at the bottom of that page are not ported: both are Subversion-era and the repository has been on git for years.

### Verified

`bundle exec jekyll build` clean. The new `###` section appears in the generated ToC; its `####` subsections correctly do not, since `_config.yml` sets `toc_levels: 1..3`.

### Next

Once this merges, the seven cwiki release pages get replaced with pointer stubs, as recorded in #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)