### PR TITLE
ci: show the Struts tag in the javadocs build name

### DIFF
--- a/Jenkinsfile.javadocs
+++ b/Jenkinsfile.javadocs
@@ -26,6 +26,10 @@ pipeline {
   stages {
     stage('Build Struts & Maven site') {
       steps {
+        // Show the tag being built in the build history, next to the build number.
+        script {
+          currentBuild.displayName = "#${env.BUILD_NUMBER} ${params.STRUTS_TAG}"
+        }
         sh '''
           echo "Building Struts ${STRUTS_TAG} and staging the Maven site"
 


### PR DESCRIPTION
The `Struts-site-javadocs` build history only showed the build number (e.g. `#8`), so there was no way to tell which `STRUTS_TAG` a run had built without opening it.

Set `currentBuild.displayName` to `#<number> <tag>` at the start of the first stage, so runs read as `#8 STRUTS_7_2_1`.

Note: the name is applied once the build starts executing — a queued build still shows the bare number briefly. Declarative Pipeline has no earlier hook for this.